### PR TITLE
[ST-0154] 用户帮助：三场景操作指南（Web）

### DIFF
--- a/apps/web/src/features/help/HelpDialog.loadError.test.tsx
+++ b/apps/web/src/features/help/HelpDialog.loadError.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./helpContent', () => {
+  return {
+    get HELP_CONTENT() {
+      throw new Error('boom');
+    },
+  };
+});
+
+import { HelpDialog } from './HelpDialog';
+
+describe('HelpDialog (load error)', () => {
+  it('renders a localized load error message', async () => {
+    render(<HelpDialog open locale="en" onClose={() => {}} />);
+
+    expect(await screen.findByText('Failed to load: boom')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/help/HelpDialog.loadError.test.tsx
+++ b/apps/web/src/features/help/HelpDialog.loadError.test.tsx
@@ -13,8 +13,18 @@ import { HelpDialog } from './HelpDialog';
 
 describe('HelpDialog (load error)', () => {
   it('renders a localized load error message', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     render(<HelpDialog open locale="en" onClose={() => {}} />);
 
-    expect(await screen.findByText('Failed to load: boom')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Unable to load help content. Please try again.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('boom')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[HelpDialog] Failed to load help content',
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
   });
 });

--- a/apps/web/src/features/help/HelpDialog.retry.test.tsx
+++ b/apps/web/src/features/help/HelpDialog.retry.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+let accessCount = 0;
+
+vi.mock('./helpContent', () => {
+  accessCount = 0;
+  return {
+    get HELP_CONTENT() {
+      accessCount += 1;
+      if (accessCount === 1) throw new Error('boom');
+
+      return {
+        'zh-CN': {
+          title: '用户帮助',
+          subtitle: 'Mock subtitle zh',
+          sections: [],
+        },
+        en: {
+          title: 'Help',
+          subtitle: 'Mock subtitle',
+          sections: [
+            {
+              title: 'Mock section',
+              items: [
+                {
+                  title: 'Mock item',
+                  description: 'Mock description',
+                  links: [{ label: 'Safe link', href: 'https://example.com' }],
+                },
+              ],
+            },
+          ],
+        },
+      };
+    },
+  };
+});
+
+import { HelpDialog } from './HelpDialog';
+
+describe('HelpDialog (retry)', () => {
+  it('retries loading content after a failure', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<HelpDialog open locale="en" onClose={() => {}} />);
+
+    expect(
+      await screen.findByText('Unable to load help content. Please try again.'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('Mock subtitle')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Mock section' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Safe link' })).toBeInTheDocument();
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+});
+

--- a/apps/web/src/features/help/HelpDialog.security.test.tsx
+++ b/apps/web/src/features/help/HelpDialog.security.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./helpContent', () => {
+  return {
+    HELP_CONTENT: {
+      'zh-CN': {
+        title: '用户帮助',
+        subtitle: '测试',
+        sections: [],
+      },
+      en: {
+        title: 'Help',
+        subtitle: 'Security test',
+        sections: [
+          {
+            title: 'Links',
+            items: [
+              {
+                title: 'Item',
+                description: 'Description',
+                links: [
+                  { label: 'Safe', href: 'https://example.com' },
+                  { label: 'Evil', href: 'javascript:alert(1)' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+});
+
+import { HelpDialog } from './HelpDialog';
+
+describe('HelpDialog (link safety)', () => {
+  it('filters out non-http(s) href values', async () => {
+    render(<HelpDialog open locale="en" onClose={() => {}} />);
+
+    await screen.findByRole('dialog', { name: 'Help' });
+
+    expect(screen.getByRole('link', { name: 'Safe' })).toHaveAttribute(
+      'href',
+      'https://example.com',
+    );
+    expect(screen.queryByRole('link', { name: 'Evil' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Evil')).not.toBeInTheDocument();
+  });
+});
+

--- a/apps/web/src/features/help/HelpDialog.test.tsx
+++ b/apps/web/src/features/help/HelpDialog.test.tsx
@@ -15,15 +15,31 @@ describe('HelpDialog', () => {
   it('renders loading state first and then locale content', async () => {
     render(<HelpDialog open locale="en" onClose={() => {}} />);
 
-    expect(screen.getByRole('dialog', { name: 'Loading' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Loading…' })).toBeInTheDocument();
     expect(screen.getByText('Loading…')).toBeInTheDocument();
     expect(screen.getByText('Loading help content')).toBeInTheDocument();
     expect(screen.getByText('Please wait…')).toBeInTheDocument();
 
     expect(await screen.findByRole('dialog', { name: 'Help' })).toBeInTheDocument();
 
-    expect(screen.getByText('Core Workflows (Web)')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Core Workflows (Web)' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Unreal Engine (UE)' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'FAQ' })).toBeInTheDocument();
     expect(screen.getByText('Local mode (Upward view)')).toBeInTheDocument();
+  });
+
+  it('uses aria-labelledby for the dialog title', async () => {
+    render(<HelpDialog open locale="en" onClose={() => {}} />);
+
+    const dialog = await screen.findByRole('dialog', { name: 'Help' });
+    expect(dialog).toHaveAttribute('aria-labelledby');
+    expect(dialog).not.toHaveAttribute('aria-label');
+
+    const title = screen.getByRole('heading', { level: 2, name: 'Help' });
+    expect(title).toHaveAttribute('id');
+    expect(dialog.getAttribute('aria-labelledby')).toBe(title.getAttribute('id'));
   });
 
   it('renders locale content and only closes on overlay click', async () => {

--- a/apps/web/src/features/help/HelpDialog.tsx
+++ b/apps/web/src/features/help/HelpDialog.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useModal } from '../../lib/useModal';
+import type { HelpContent } from './helpContent';
+import { HELP_UI_STRINGS, type HelpLocale } from './helpUiStrings';
+
+type Props = {
+  open: boolean;
+  locale?: HelpLocale;
+  onClose: () => void;
+};
+
+export function HelpDialog({ open, locale = 'zh-CN', onClose }: Props) {
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const [content, setContent] = useState<Record<HelpLocale, HelpContent> | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const { onOverlayMouseDown } = useModal({
+    open,
+    modalRef,
+    initialFocusRef: closeButtonRef,
+    onClose,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    if (content) return;
+
+    let cancelled = false;
+    setLoadError(null);
+
+    void import('./helpContent')
+      .then((module) => {
+        if (cancelled) return;
+        setContent(module.HELP_CONTENT);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setLoadError(error instanceof Error ? error.message : String(error));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [content, open]);
+
+  if (!open) return null;
+
+  const uiStrings = HELP_UI_STRINGS[locale];
+  const dialogContent = content ? content[locale] : null;
+  const dialogTitle = dialogContent?.title ?? uiStrings.loadingDialogTitle;
+  const dialogSubtitle = dialogContent?.subtitle ?? uiStrings.loadingDialogSubtitle;
+  const dialogLabel = dialogContent?.title ?? uiStrings.loadingDialogAriaLabel;
+
+  return createPortal(
+    <div
+      className="modalOverlay"
+      role="presentation"
+      data-testid="help-overlay"
+      onMouseDown={onOverlayMouseDown}
+    >
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={dialogLabel}
+        ref={modalRef}
+      >
+        <div className="modalHeader">
+          <div>
+            <h2 className="modalTitle">{dialogTitle}</h2>
+            <div className="modalMeta">{dialogSubtitle}</div>
+          </div>
+          <div className="modalHeaderActions">
+            <button
+              type="button"
+              className="modalButton"
+              onClick={onClose}
+              ref={closeButtonRef}
+              aria-label={uiStrings.closeButtonAriaLabel}
+            >
+              {uiStrings.closeButtonText}
+            </button>
+          </div>
+        </div>
+
+        <div className="modalBody">
+          {loadError ? (
+            <p className="modalError">
+              {uiStrings.loadErrorPrefix}: {loadError}
+            </p>
+          ) : dialogContent ? (
+            dialogContent.sections.map((section) => (
+              <section key={section.title} className="grid gap-2">
+                <p className="modalSectionTitle">{section.title}</p>
+                <ul className="modalList">
+                  {section.items.map((item) => (
+                    <li key={item.title} className="modalListItem">
+                      <div className="font-semibold text-slate-100">{item.title}</div>
+                      <div className="whitespace-pre-line text-slate-200">{item.description}</div>
+                      {item.links?.length ? (
+                        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+                          {item.links.map((link) => (
+                            <a
+                              key={link.href}
+                              href={link.href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inlineLink"
+                            >
+                              {link.label}
+                            </a>
+                          ))}
+                        </div>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))
+          ) : (
+            <p className="modalMeta">{uiStrings.loadingDialogBody}</p>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+

--- a/apps/web/src/features/help/HelpLauncher.test.tsx
+++ b/apps/web/src/features/help/HelpLauncher.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { HelpLauncher } from './HelpLauncher';
+
+describe('HelpLauncher', () => {
+  it('renders entry button and opens/closes dialog', async () => {
+    const user = userEvent.setup();
+    render(<HelpLauncher />);
+
+    const triggerButton = screen.getByRole('button', { name: '打开用户帮助' });
+    expect(triggerButton).toBeInTheDocument();
+    expect(triggerButton).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('dialog', { name: '用户帮助' })).not.toBeInTheDocument();
+
+    await user.click(triggerButton);
+
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'true');
+    expect(await screen.findByRole('dialog', { name: '用户帮助' })).toBeInTheDocument();
+
+    expect(screen.getByText('三场景操作指南（Web）')).toBeInTheDocument();
+    expect(screen.getByText('点位仰视模式（Local mode）')).toBeInTheDocument();
+    expect(screen.getByText('锁层模式（LayerGlobal mode）')).toBeInTheDocument();
+    expect(screen.getByText('事件模式（Event mode）')).toBeInTheDocument();
+
+    expect(screen.getByText('常见问题（FAQ）')).toBeInTheDocument();
+    expect(screen.getByText('数据缺失处理')).toBeInTheDocument();
+    expect(screen.getByText('性能模式切换')).toBeInTheDocument();
+    expect(screen.getByText('数据归因说明')).toBeInTheDocument();
+
+    const closeButton = await screen.findByRole('button', { name: '关闭弹窗' });
+    await waitFor(() => expect(closeButton).toHaveFocus());
+
+    await user.click(closeButton);
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: '用户帮助' })).not.toBeInTheDocument(),
+    );
+
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+    await waitFor(() => expect(triggerButton).toHaveFocus());
+  });
+
+  it('closes via Escape key', async () => {
+    const user = userEvent.setup();
+    render(<HelpLauncher />);
+
+    const triggerButton = screen.getByRole('button', { name: '打开用户帮助' });
+    await user.click(triggerButton);
+    await screen.findByRole('dialog', { name: '用户帮助' });
+
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: '用户帮助' })).not.toBeInTheDocument(),
+    );
+
+    await waitFor(() => expect(triggerButton).toHaveFocus());
+  });
+
+  it('supports localized UI strings', async () => {
+    const user = userEvent.setup();
+    render(<HelpLauncher locale="en" />);
+
+    const triggerButton = screen.getByRole('button', { name: 'Open help' });
+    expect(triggerButton).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(triggerButton);
+
+    expect(await screen.findByRole('dialog', { name: 'Help' })).toBeInTheDocument();
+    expect(screen.getByText('Core Workflows (Web)')).toBeInTheDocument();
+
+    const closeButton = await screen.findByRole('button', { name: 'Close dialog' });
+    expect(closeButton).toHaveTextContent('Close');
+  });
+});
+

--- a/apps/web/src/features/help/HelpLauncher.tsx
+++ b/apps/web/src/features/help/HelpLauncher.tsx
@@ -1,0 +1,38 @@
+import { useCallback, useState } from 'react';
+
+import { HelpDialog } from './HelpDialog';
+import { HELP_UI_STRINGS, type HelpLocale } from './helpUiStrings';
+
+type Props = {
+  locale?: HelpLocale;
+};
+
+export function HelpLauncher({ locale = 'zh-CN' }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const onOpen = useCallback(() => {
+    setOpen(true);
+  }, []);
+
+  const onClose = useCallback(() => setOpen(false), []);
+  const uiStrings = HELP_UI_STRINGS[locale];
+
+  return (
+    <>
+      <button
+        type="button"
+        className="helpFab"
+        onClick={onOpen}
+        aria-label={uiStrings.openButtonAriaLabel}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title={uiStrings.openButtonTitle}
+      >
+        ?
+      </button>
+
+      <HelpDialog open={open} onClose={onClose} locale={locale} />
+    </>
+  );
+}
+

--- a/apps/web/src/features/help/helpContent.ts
+++ b/apps/web/src/features/help/helpContent.ts
@@ -1,0 +1,159 @@
+import type { HelpLocale } from './helpUiStrings';
+
+export type HelpLink = {
+  label: string;
+  href: string;
+};
+
+export type HelpItem = {
+  title: string;
+  description: string;
+  links?: HelpLink[];
+};
+
+export type HelpSection = {
+  title: string;
+  items: HelpItem[];
+};
+
+export type HelpContent = {
+  title: string;
+  subtitle: string;
+  sections: HelpSection[];
+};
+
+export const HELP_CONTENT: Record<HelpLocale, HelpContent> = {
+  'zh-CN': {
+    title: '用户帮助',
+    subtitle: '三场景操作指南与常见问题',
+    sections: [
+      {
+        title: '三场景操作指南（Web）',
+        items: [
+          {
+            title: '点位仰视模式（Local mode）',
+            description: [
+              '进入：在地球上双击，或按住 Ctrl 单击任意位置，进入局地（Local）视图。',
+              '仰视：在「局地信息」面板的「相机视角」中选择「仰视」。也可以切换「平视 / 自由」。',
+              '退出：点击面板中的「返回」或信息面板的「返回上一视图」。',
+            ].join('\n'),
+          },
+          {
+            title: '锁层模式（LayerGlobal mode）',
+            description: [
+              '进入：在左侧「图层」列表中点击任意图层；或在 Local 模式点击「锁定当前层」。',
+              '用途：专注查看单个图层的渲染效果，并可调整可见性与透明度。',
+              '退出：点击信息面板的「返回上一视图」。',
+            ].join('\n'),
+          },
+          {
+            title: '事件模式（Event mode）',
+            description: [
+              '进入：打开信息面板 →「当前」→「事件列表」，点击任意事件进入。',
+              '浏览：事件被选中后，可在地图上查看相关标注；点击点位可查看该事件下的风险/信息（如有）。',
+              '退出：点击信息面板的「返回上一视图」。',
+            ].join('\n'),
+          },
+        ],
+      },
+      {
+        title: '常见问题（FAQ）',
+        items: [
+          {
+            title: '数据缺失处理',
+            description: [
+              '当图层出现灰显或提示「数据缺失，已降级展示。」时，表示当前时间/区域可能缺测或请求失败。',
+              '建议：切换时间帧；尝试其他图层；检查网络/接口是否可用；必要时刷新页面重试。',
+            ].join('\n'),
+          },
+          {
+            title: '性能模式切换',
+            description: [
+              '位置：信息面板 →「设置」→「性能模式」。',
+              'Low 模式会减少粒子与风矢密度，并关闭体云/建筑（如有），以提升低性能设备体验。',
+              '可结合右侧 FPS 指标判断是否需要切换。',
+            ].join('\n'),
+          },
+          {
+            title: '数据归因说明',
+            description: [
+              '页面底部的「归因与数据来源」栏会显示当前数据/底图/引擎的归因摘要。',
+              '可点击「数据来源」与「免责声明」查看详细说明。',
+              '右下角的「i」按钮也可快速查看数据来源与免责声明（静态说明）。',
+            ].join('\n'),
+            links: [
+              { label: 'GitHub Repo', href: 'https://github.com/DankerMu/Digital-earth' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  en: {
+    title: 'Help',
+    subtitle: 'Workflows and FAQs',
+    sections: [
+      {
+        title: 'Core Workflows (Web)',
+        items: [
+          {
+            title: 'Local mode (Upward view)',
+            description: [
+              'Enter: double-click on the globe, or Ctrl + Click anywhere to enter Local mode.',
+              'Upward view: in the “Local info” panel, switch camera perspective to “Upward” (or “Forward / Free”).',
+              'Exit: use “Back” in the panel or “Back to previous view” in the info panel.',
+            ].join('\n'),
+          },
+          {
+            title: 'Layer lock mode (LayerGlobal mode)',
+            description: [
+              'Enter: click any layer in the Layer tree; or click “Lock current layer” in Local mode.',
+              'Purpose: focus on a single layer and adjust visibility/opacity.',
+              'Exit: click “Back to previous view” in the info panel.',
+            ].join('\n'),
+          },
+          {
+            title: 'Event mode',
+            description: [
+              'Enter: Info panel → “Current” → “Event list”, then select an event.',
+              'Explore: after selecting an event, related markers may appear on the map; click POIs to inspect event-specific details (if available).',
+              'Exit: click “Back to previous view” in the info panel.',
+            ].join('\n'),
+          },
+        ],
+      },
+      {
+        title: 'FAQ',
+        items: [
+          {
+            title: 'Missing data',
+            description: [
+              'If a layer is grayed out or shows a missing data message, the selected time/area may be unavailable or the request failed.',
+              'Try switching time frames, trying another layer, checking network/API status, or refreshing the page.',
+            ].join('\n'),
+          },
+          {
+            title: 'Performance mode',
+            description: [
+              'Where: Info panel → “Settings” → “Performance mode”.',
+              'Low reduces particle density and disables heavy effects (e.g. volumetric clouds/buildings) to improve performance.',
+              'Use the FPS indicator to decide which mode to use.',
+            ].join('\n'),
+          },
+          {
+            title: 'Attribution',
+            description: [
+              'The footer “Attribution & sources” shows a summary for active data/basemap/engine.',
+              'Use “Sources” and “Disclaimer” for full details.',
+              'The “i” button in the bottom-right also provides a quick static overview.',
+            ].join('\n'),
+            links: [
+              { label: 'GitHub Repo', href: 'https://github.com/DankerMu/Digital-earth' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};
+

--- a/apps/web/src/features/help/helpContent.ts
+++ b/apps/web/src/features/help/helpContent.ts
@@ -57,6 +57,18 @@ export const HELP_CONTENT: Record<HelpLocale, HelpContent> = {
         ],
       },
       {
+        title: 'UE 操作指南（UE）',
+        items: [
+          {
+            title: '即将上线',
+            description: [
+              '当前版本仅包含 Web 端帮助内容。',
+              'UE（Unreal Engine）端操作指南将在后续版本提供。',
+            ].join('\n'),
+          },
+        ],
+      },
+      {
         title: '常见问题（FAQ）',
         items: [
           {
@@ -123,6 +135,18 @@ export const HELP_CONTENT: Record<HelpLocale, HelpContent> = {
         ],
       },
       {
+        title: 'Unreal Engine (UE)',
+        items: [
+          {
+            title: 'Coming soon',
+            description: [
+              'This help dialog currently covers Web only.',
+              'UE (Unreal Engine) guides will be available in a future release.',
+            ].join('\n'),
+          },
+        ],
+      },
+      {
         title: 'FAQ',
         items: [
           {
@@ -156,4 +180,3 @@ export const HELP_CONTENT: Record<HelpLocale, HelpContent> = {
     ],
   },
 };
-

--- a/apps/web/src/features/help/helpUiStrings.ts
+++ b/apps/web/src/features/help/helpUiStrings.ts
@@ -8,6 +8,8 @@ export type HelpUiStrings = {
   loadingDialogSubtitle: string;
   loadingDialogBody: string;
   loadErrorPrefix: string;
+  loadErrorMessage: string;
+  retryButtonText: string;
   closeButtonAriaLabel: string;
   closeButtonText: string;
 };
@@ -21,6 +23,8 @@ export const HELP_UI_STRINGS: Record<HelpLocale, HelpUiStrings> = {
     loadingDialogSubtitle: '正在加载用户帮助',
     loadingDialogBody: '请稍候…',
     loadErrorPrefix: '加载失败',
+    loadErrorMessage: '加载用户帮助失败，请重试。',
+    retryButtonText: '重试',
     closeButtonAriaLabel: '关闭弹窗',
     closeButtonText: '关闭',
   },
@@ -32,8 +36,9 @@ export const HELP_UI_STRINGS: Record<HelpLocale, HelpUiStrings> = {
     loadingDialogSubtitle: 'Loading help content',
     loadingDialogBody: 'Please wait…',
     loadErrorPrefix: 'Failed to load',
+    loadErrorMessage: 'Unable to load help content. Please try again.',
+    retryButtonText: 'Retry',
     closeButtonAriaLabel: 'Close dialog',
     closeButtonText: 'Close',
   },
 };
-

--- a/apps/web/src/features/help/helpUiStrings.ts
+++ b/apps/web/src/features/help/helpUiStrings.ts
@@ -1,0 +1,39 @@
+export type HelpLocale = 'zh-CN' | 'en';
+
+export type HelpUiStrings = {
+  openButtonAriaLabel: string;
+  openButtonTitle: string;
+  loadingDialogAriaLabel: string;
+  loadingDialogTitle: string;
+  loadingDialogSubtitle: string;
+  loadingDialogBody: string;
+  loadErrorPrefix: string;
+  closeButtonAriaLabel: string;
+  closeButtonText: string;
+};
+
+export const HELP_UI_STRINGS: Record<HelpLocale, HelpUiStrings> = {
+  'zh-CN': {
+    openButtonAriaLabel: '打开用户帮助',
+    openButtonTitle: '用户帮助',
+    loadingDialogAriaLabel: '加载中',
+    loadingDialogTitle: '加载中…',
+    loadingDialogSubtitle: '正在加载用户帮助',
+    loadingDialogBody: '请稍候…',
+    loadErrorPrefix: '加载失败',
+    closeButtonAriaLabel: '关闭弹窗',
+    closeButtonText: '关闭',
+  },
+  en: {
+    openButtonAriaLabel: 'Open help',
+    openButtonTitle: 'Help',
+    loadingDialogAriaLabel: 'Loading',
+    loadingDialogTitle: 'Loading…',
+    loadingDialogSubtitle: 'Loading help content',
+    loadingDialogBody: 'Please wait…',
+    loadErrorPrefix: 'Failed to load',
+    closeButtonAriaLabel: 'Close dialog',
+    closeButtonText: 'Close',
+  },
+};
+

--- a/apps/web/src/features/layout/AppLayout.tsx
+++ b/apps/web/src/features/layout/AppLayout.tsx
@@ -154,10 +154,10 @@ export function AppLayout() {
           </div>
         </div>
 
-      <LegendPanel
-        collapsed={isLegendCollapsed}
-        onToggleCollapsed={toggleLegendCollapsed}
-      />
+        <LegendPanel
+          collapsed={isLegendCollapsed}
+          onToggleCollapsed={toggleLegendCollapsed}
+        />
       </div>
 
       <HelpLauncher />

--- a/apps/web/src/features/layout/AppLayout.tsx
+++ b/apps/web/src/features/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import type { LayerConfig } from '../../state/layerManager';
 import { useLayerManagerStore } from '../../state/layerManager';
 import { CesiumViewer } from '../viewer/CesiumViewer';
 import { DisclaimerLauncher } from '../disclaimer/DisclaimerLauncher';
+import { HelpLauncher } from '../help/HelpLauncher';
 import { InfoPanel } from './InfoPanel';
 import { LayerTree } from './LayerTree';
 import { LegendPanel } from './LegendPanel';
@@ -153,12 +154,13 @@ export function AppLayout() {
           </div>
         </div>
 
-        <LegendPanel
-          collapsed={isLegendCollapsed}
-          onToggleCollapsed={toggleLegendCollapsed}
-        />
+      <LegendPanel
+        collapsed={isLegendCollapsed}
+        onToggleCollapsed={toggleLegendCollapsed}
+      />
       </div>
 
+      <HelpLauncher />
       <DisclaimerLauncher />
     </div>
   );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -466,9 +466,9 @@ body {
   color: rgba(147, 197, 253, 1);
 }
 
-.disclaimerFab {
+.disclaimerFab,
+.helpFab {
   position: fixed;
-  right: calc(1rem + env(safe-area-inset-right) + var(--disclaimer-fab-offset-right, 0px));
   bottom: calc(1rem + env(safe-area-inset-bottom) + var(--disclaimer-fab-offset-bottom, 0px));
   z-index: 45;
   display: inline-flex;
@@ -488,16 +488,27 @@ body {
   transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
 }
 
-.disclaimerFab:hover {
+.disclaimerFab {
+  right: calc(1rem + env(safe-area-inset-right) + var(--disclaimer-fab-offset-right, 0px));
+}
+
+.helpFab {
+  right: calc(1rem + env(safe-area-inset-right) + var(--disclaimer-fab-offset-right, 0px) + 48px);
+}
+
+.disclaimerFab:hover,
+.helpFab:hover {
   background: rgba(30, 41, 59, 0.85);
   border-color: rgba(148, 163, 184, 0.3);
 }
 
-.disclaimerFab:active {
+.disclaimerFab:active,
+.helpFab:active {
   transform: translateY(1px);
 }
 
-.disclaimerFab:focus-visible {
+.disclaimerFab:focus-visible,
+.helpFab:focus-visible {
   outline: 2px solid rgba(96, 165, 250, 1);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
实现用户帮助文档（Web 部分）

**注意**: 本 PR 仅实现 Web 场景帮助，UE 部分将在后续版本中添加。

## Changes
- 右下角添加 "?" 浮动入口按钮（与 "i" 按钮并排）
- 创建 HelpDialog 帮助弹窗组件
- 覆盖三大 Web 场景：
  - 点位仰视模式 (Local mode)
  - 锁层模式 (LayerGlobal mode)  
  - 事件模式 (Event mode)
- 添加常见问题 FAQ：
  - 数据缺失处理
  - 性能模式切换
  - 数据归因说明
- 添加 UE 帮助占位符（说明后续版本提供）
- 支持 zh-CN/en 两种语言
- 懒加载优化性能
- 完整的单元测试覆盖（>= 90%）
- 复用 useModal hook（focus trap、background inert、Escape/overlay close）
- 安全性增强（链接 scheme 校验、友好错误提示）

## Test Plan
- [x] 单元测试全部通过
- [x] 测试覆盖率达标（>= 90%）
- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过
- [x] E2E 测试通过

## Related Issues
Partially addresses #185 (Web 部分完成，UE 部分待后续实现)