### PR TITLE
[ST-0066] 产品编辑器 UI：创建/编辑产品基础信息 (#97)

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,9 +1,0 @@
----
-active: true
-iteration: 1
-max_iterations: 5
-completion_promise: "TASK_COMPLETE"
-started_at: "2026-01-22T10:06:26Z"
----
-
-结合当前进度，严格执行gh-flow的流程（CI必须通过，pr必须通过codeagent进行review，提出的所有问题必须修复，且调用codeagent修复），串行完成v1阶段非UE组件issues的实现，When ALL issues are implement, output exactly: TASK_COMPLETE 

--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -2,8 +2,8 @@
 active: true
 iteration: 1
 max_iterations: 5
-completion_promise: null
-started_at: "2026-01-21T08:11:58Z"
+completion_promise: "TASK_COMPLETE"
+started_at: "2026-01-22T10:06:26Z"
 ---
 
-结合当前进度，按照gh-flow的流程，严格执行，完成v0阶段非UE组件issues的实现
+结合当前进度，严格执行gh-flow的流程（CI必须通过，pr必须通过codeagent进行review，提出的所有问题必须修复，且调用codeagent修复），串行完成v1阶段非UE组件issues的实现，When ALL issues are implement, output exactly: TASK_COMPLETE 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ npm-debug.log*
 .parcel-cache/
 .pytest_cache/
 
+# Local tooling configs
+.claude/*.local.*
+
 # Test coverage
 coverage/
 .nyc_output/

--- a/apps/web/src/features/products/ProductEditor.test.tsx
+++ b/apps/web/src/features/products/ProductEditor.test.tsx
@@ -4,14 +4,15 @@ import { describe, expect, it, vi } from 'vitest';
 
 const STORAGE_KEY = 'digital-earth.productDraft';
 
-async function importFresh() {
+async function importFreshEditor() {
   vi.resetModules();
   return await import('./ProductEditor');
 }
 
 describe('ProductEditor', () => {
   it('validateProductEditor reports invalid time values', async () => {
-    const { validateProductEditor } = await importFresh();
+    vi.resetModules();
+    const { validateProductEditor } = await import('./productEditorValidation');
     const errors = validateProductEditor({
       title: 't',
       type: 'snow',
@@ -29,7 +30,7 @@ describe('ProductEditor', () => {
 
   it('shows required field errors and blocks submit', async () => {
     localStorage.removeItem(STORAGE_KEY);
-    const { ProductEditor } = await importFresh();
+    const { ProductEditor } = await importFreshEditor();
     const onSubmit = vi.fn();
     const onClose = vi.fn();
 
@@ -44,7 +45,7 @@ describe('ProductEditor', () => {
 
   it('validates time ordering rules', async () => {
     localStorage.removeItem(STORAGE_KEY);
-    const { ProductEditor } = await importFresh();
+    const { ProductEditor } = await importFreshEditor();
     const onSubmit = vi.fn();
     const onClose = vi.fn();
 
@@ -70,7 +71,7 @@ describe('ProductEditor', () => {
 
   it('submits normalized values, clears draft, and closes', async () => {
     localStorage.removeItem(STORAGE_KEY);
-    const { ProductEditor } = await importFresh();
+    const { ProductEditor } = await importFreshEditor();
     const onSubmit = vi.fn();
     const onClose = vi.fn();
 
@@ -116,7 +117,7 @@ describe('ProductEditor', () => {
 
   it('restores a saved draft after module reload', async () => {
     localStorage.removeItem(STORAGE_KEY);
-    const { ProductEditor: ProductEditor1 } = await importFresh();
+    const { ProductEditor: ProductEditor1 } = await importFreshEditor();
 
     const first = render(<ProductEditor1 open onClose={() => {}} onSubmit={() => {}} />);
     const user = userEvent.setup();
@@ -134,7 +135,7 @@ describe('ProductEditor', () => {
     first.unmount();
 
     // Simulate a page refresh by re-importing modules.
-    const { ProductEditor: ProductEditor2 } = await importFresh();
+    const { ProductEditor: ProductEditor2 } = await importFreshEditor();
 
     render(<ProductEditor2 open onClose={() => {}} onSubmit={() => {}} />);
 
@@ -145,7 +146,7 @@ describe('ProductEditor', () => {
 
   it('shows a submit error when onSubmit throws', async () => {
     localStorage.removeItem(STORAGE_KEY);
-    const { ProductEditor } = await importFresh();
+    const { ProductEditor } = await importFreshEditor();
     const onSubmit = vi.fn(() => {
       throw new Error('boom');
     });

--- a/apps/web/src/features/products/ProductEditor.test.tsx
+++ b/apps/web/src/features/products/ProductEditor.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'digital-earth.productDraft';
+
+async function importFresh() {
+  vi.resetModules();
+  return await import('./ProductEditor');
+}
+
+describe('ProductEditor', () => {
+  it('validateProductEditor reports invalid time values', async () => {
+    const { validateProductEditor } = await importFresh();
+    const errors = validateProductEditor({
+      title: 't',
+      type: 'snow',
+      severity: '',
+      text: 'body',
+      issued_at: 'not-a-date',
+      valid_from: 'still-not-a-date',
+      valid_to: 'nope',
+    });
+
+    expect(errors.issued_at).toBe('请输入合法的时间');
+    expect(errors.valid_from).toBe('请输入合法的时间');
+    expect(errors.valid_to).toBe('请输入合法的时间');
+  });
+
+  it('shows required field errors and blocks submit', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { ProductEditor } = await importFresh();
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+
+    render(<ProductEditor open onClose={onClose} onSubmit={onSubmit} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '提交' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getAllByText('此项为必填')).toHaveLength(6);
+  });
+
+  it('validates time ordering rules', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { ProductEditor } = await importFresh();
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+
+    render(<ProductEditor open onClose={onClose} onSubmit={onSubmit} />);
+
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/标题/), '测试产品');
+    await user.type(screen.getByLabelText(/类型/), '降雪');
+    await user.type(screen.getByLabelText(/正文/), '这里是正文');
+
+    await user.type(screen.getByLabelText(/发布时间/), '2026-01-01T03:00');
+    await user.type(screen.getByLabelText(/有效开始时间/), '2026-01-01T02:00');
+    await user.type(screen.getByLabelText(/有效结束时间/), '2026-01-01T01:00');
+
+    await user.click(screen.getByRole('button', { name: '提交' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(await screen.findByText('结束时间必须晚于开始时间')).toBeInTheDocument();
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts.map((node) => node.textContent)).toContain('发布时间需早于或等于有效开始时间');
+  });
+
+  it('submits normalized values, clears draft, and closes', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { ProductEditor } = await importFresh();
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+
+    render(<ProductEditor open onClose={onClose} onSubmit={onSubmit} />);
+
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/标题/), '  测试产品  ');
+    await user.type(screen.getByLabelText(/类型/), '  降雪  ');
+    await user.selectOptions(screen.getByLabelText(/严重程度/), 'high');
+    await user.type(screen.getByLabelText(/正文/), '  这里是正文  ');
+
+    await user.type(screen.getByLabelText(/发布时间/), '2026-01-01T00:00');
+    await user.type(screen.getByLabelText(/有效开始时间/), '2026-01-01T00:00');
+    await user.type(screen.getByLabelText(/有效结束时间/), '2026-01-02T00:00');
+
+    await user.click(screen.getByRole('button', { name: '保存草稿' }));
+    expect(screen.getByText('草稿已保存')).toBeInTheDocument();
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+    await user.click(screen.getByRole('button', { name: '提交' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      title: '测试产品',
+      type: '降雪',
+      severity: 'high',
+      text: '这里是正文',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T00:00',
+      valid_to: '2026-01-02T00:00',
+    });
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('restores a saved draft after module reload', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { ProductEditor: ProductEditor1 } = await importFresh();
+
+    const first = render(<ProductEditor1 open onClose={() => {}} onSubmit={() => {}} />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/标题/), 'Draft title');
+    await user.type(screen.getByLabelText(/类型/), 'storm');
+    await user.type(screen.getByLabelText(/正文/), 'draft body');
+    await user.type(screen.getByLabelText(/发布时间/), '2026-01-01T00:00');
+    await user.type(screen.getByLabelText(/有效开始时间/), '2026-01-01T01:00');
+    await user.type(screen.getByLabelText(/有效结束时间/), '2026-01-01T02:00');
+    await user.click(screen.getByRole('button', { name: '保存草稿' }));
+
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+    first.unmount();
+
+    // Simulate a page refresh by re-importing modules.
+    const { ProductEditor: ProductEditor2 } = await importFresh();
+
+    render(<ProductEditor2 open onClose={() => {}} onSubmit={() => {}} />);
+
+    expect(screen.getByLabelText(/标题/)).toHaveValue('Draft title');
+    expect(screen.getByLabelText(/类型/)).toHaveValue('storm');
+    expect(screen.getByLabelText(/正文/)).toHaveValue('draft body');
+  });
+
+  it('shows a submit error when onSubmit throws', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { ProductEditor } = await importFresh();
+    const onSubmit = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const onClose = vi.fn();
+
+    render(<ProductEditor open onClose={onClose} onSubmit={onSubmit} />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/标题/), 'T');
+    await user.type(screen.getByLabelText(/类型/), 'Type');
+    await user.type(screen.getByLabelText(/正文/), 'Body');
+    await user.type(screen.getByLabelText(/发布时间/), '2026-01-01T00:00');
+    await user.type(screen.getByLabelText(/有效开始时间/), '2026-01-01T00:00');
+    await user.type(screen.getByLabelText(/有效结束时间/), '2026-01-02T00:00');
+
+    await user.click(screen.getByRole('button', { name: '提交' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('提交失败：boom');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/products/ProductEditor.tsx
+++ b/apps/web/src/features/products/ProductEditor.tsx
@@ -1,0 +1,455 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useModal } from '../../lib/useModal';
+import { createEmptyProductDraft, useProductDraftStore, type ProductDraft } from '../../state/productDraft';
+
+export type ProductEditorValues = ProductDraft;
+
+type ProductEditorErrors = Partial<Record<keyof ProductEditorValues, string>> & {
+  form?: string;
+};
+
+function normalizeText(value: string): string {
+  return value.trim();
+}
+
+function toEpochMs(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const date = new Date(trimmed);
+  const ms = date.getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+export function validateProductEditor(values: ProductEditorValues): ProductEditorErrors {
+  const errors: ProductEditorErrors = {};
+
+  const required: Array<keyof ProductEditorValues> = [
+    'title',
+    'text',
+    'issued_at',
+    'valid_from',
+    'valid_to',
+    'type',
+  ];
+
+  for (const field of required) {
+    if (!normalizeText(values[field])) {
+      errors[field] = '此项为必填';
+    }
+  }
+
+  const issuedAtMs = toEpochMs(values.issued_at);
+  if (normalizeText(values.issued_at) && issuedAtMs == null) {
+    errors.issued_at = '请输入合法的时间';
+  }
+
+  const validFromMs = toEpochMs(values.valid_from);
+  if (normalizeText(values.valid_from) && validFromMs == null) {
+    errors.valid_from = '请输入合法的时间';
+  }
+
+  const validToMs = toEpochMs(values.valid_to);
+  if (normalizeText(values.valid_to) && validToMs == null) {
+    errors.valid_to = '请输入合法的时间';
+  }
+
+  if (validFromMs != null && validToMs != null && validFromMs >= validToMs) {
+    errors.valid_to = '结束时间必须晚于开始时间';
+  }
+
+  if (issuedAtMs != null && validFromMs != null && issuedAtMs > validFromMs) {
+    errors.issued_at = '发布时间需早于或等于有效开始时间';
+  }
+
+  return errors;
+}
+
+function hasErrors(errors: ProductEditorErrors): boolean {
+  return Object.keys(errors).length > 0;
+}
+
+function fieldClasses(hasError: boolean): string {
+  return [
+    'mt-1 w-full rounded-lg border px-3 py-2 text-sm text-slate-100 shadow-sm outline-none transition',
+    'bg-slate-950/30 placeholder:text-slate-500',
+    hasError ? 'border-rose-400/40 focus:border-rose-400/60 focus:ring-2 focus:ring-rose-400/30' : 'border-slate-400/20 focus:border-blue-400/50 focus:ring-2 focus:ring-blue-400/30',
+  ].join(' ');
+}
+
+function normalizeValues(values: ProductEditorValues): ProductEditorValues {
+  return {
+    title: normalizeText(values.title),
+    text: normalizeText(values.text),
+    issued_at: normalizeText(values.issued_at),
+    valid_from: normalizeText(values.valid_from),
+    valid_to: normalizeText(values.valid_to),
+    type: normalizeText(values.type),
+    severity: normalizeText(values.severity),
+  };
+}
+
+type Props = {
+  open: boolean;
+  initialValues?: Partial<ProductEditorValues>;
+  title?: string;
+  onClose: () => void;
+  onSubmit: (values: ProductEditorValues) => void | Promise<void>;
+};
+
+export function ProductEditor({
+  open,
+  initialValues,
+  title = '产品编辑器',
+  onClose,
+  onSubmit,
+}: Props) {
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const baseId = useId();
+  const [values, setValues] = useState<ProductEditorValues>(() => {
+    const stored = useProductDraftStore.getState().draft;
+    const base = stored ?? (initialValues ? { ...createEmptyProductDraft(), ...initialValues } : createEmptyProductDraft());
+    return base;
+  });
+  const [errors, setErrors] = useState<ProductEditorErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saved'>('idle');
+  const [validatedOnce, setValidatedOnce] = useState(false);
+  const savedDraftUpdatedAt = useProductDraftStore((state) => state.updatedAt);
+
+  const fieldIds = useMemo(() => {
+    return {
+      title: `product-editor-title-${baseId}`,
+      text: `product-editor-text-${baseId}`,
+      issued_at: `product-editor-issued-at-${baseId}`,
+      valid_from: `product-editor-valid-from-${baseId}`,
+      valid_to: `product-editor-valid-to-${baseId}`,
+      type: `product-editor-type-${baseId}`,
+      severity: `product-editor-severity-${baseId}`,
+    };
+  }, [baseId]);
+
+  const { onOverlayMouseDown } = useModal({
+    open,
+    modalRef,
+    initialFocusRef: closeButtonRef,
+    onClose,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    const stored = useProductDraftStore.getState().draft;
+    const base = stored ?? (initialValues ? { ...createEmptyProductDraft(), ...initialValues } : createEmptyProductDraft());
+    setValues(base);
+    setErrors({});
+    setSubmitError(null);
+    setIsSubmitting(false);
+    setSaveStatus('idle');
+    setValidatedOnce(false);
+  }, [initialValues, open]);
+
+  useEffect(() => {
+    if (saveStatus !== 'saved') return;
+    const timer = window.setTimeout(() => setSaveStatus('idle'), 1600);
+    return () => window.clearTimeout(timer);
+  }, [saveStatus]);
+
+  const updatedAtLabel = useMemo(() => {
+    if (!savedDraftUpdatedAt) return null;
+    const date = new Date(savedDraftUpdatedAt);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toLocaleString();
+  }, [savedDraftUpdatedAt]);
+
+  function updateField(field: keyof ProductEditorValues, value: string) {
+    setValues((current) => {
+      const next = { ...current, [field]: value };
+      if (!validatedOnce) return next;
+      setErrors(validateProductEditor(next));
+      return next;
+    });
+  }
+
+  async function handleSubmit() {
+    setValidatedOnce(true);
+    const nextErrors = validateProductEditor(values);
+    setErrors(nextErrors);
+    if (hasErrors(nextErrors)) return;
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const normalized = normalizeValues(values);
+      await onSubmit(normalized);
+      useProductDraftStore.getState().clearDraft();
+      onClose();
+    } catch (error: unknown) {
+      setSubmitError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleSaveDraft() {
+    useProductDraftStore.getState().setDraft(values);
+    setSaveStatus('saved');
+  }
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="modalOverlay"
+      role="presentation"
+      data-testid="product-editor-overlay"
+      onMouseDown={onOverlayMouseDown}
+    >
+      <div className="modal" role="dialog" aria-modal="true" aria-label={title} ref={modalRef}>
+        <div className="modalHeader">
+          <div className="min-w-0">
+            <h2 className="modalTitle">{title}</h2>
+            <div className="modalMeta">
+              {saveStatus === 'saved' ? '草稿已保存' : updatedAtLabel ? `草稿更新时间: ${updatedAtLabel}` : '填写产品基础信息并保存草稿'}
+            </div>
+          </div>
+          <div className="modalHeaderActions">
+            <button
+              type="button"
+              className="modalButton"
+              onClick={() => {
+                useProductDraftStore.getState().clearDraft();
+                setValues(initialValues ? { ...createEmptyProductDraft(), ...initialValues } : createEmptyProductDraft());
+                setErrors({});
+                setSubmitError(null);
+                setValidatedOnce(false);
+              }}
+              aria-label="清除草稿"
+            >
+              清除草稿
+            </button>
+            <button
+              type="button"
+              className="modalButton"
+              onClick={onClose}
+              ref={closeButtonRef}
+              aria-label="关闭编辑器"
+            >
+              关闭
+            </button>
+          </div>
+        </div>
+
+        <div className="modalBody">
+          <form
+            className="grid gap-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleSubmit();
+            }}
+          >
+            {submitError ? (
+              <div className="rounded-lg border border-rose-400/20 bg-rose-500/10 p-3 text-sm text-rose-200" role="alert">
+                提交失败：{submitError}
+              </div>
+            ) : null}
+
+            {errors.form ? (
+              <div className="rounded-lg border border-rose-400/20 bg-rose-500/10 p-3 text-sm text-rose-200" role="alert">
+                {errors.form}
+              </div>
+            ) : null}
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label htmlFor={fieldIds.title} className="text-sm font-medium text-slate-200">
+                  标题 <span className="text-rose-300">*</span>
+                </label>
+                <input
+                  id={fieldIds.title}
+                  name="title"
+                  className={fieldClasses(Boolean(errors.title))}
+                  value={values.title}
+                  onChange={(event) => updateField('title', event.target.value)}
+                  aria-invalid={Boolean(errors.title)}
+                  aria-describedby={errors.title ? `${fieldIds.title}-error` : undefined}
+                  placeholder="请输入标题"
+                  autoComplete="off"
+                />
+                {errors.title ? (
+                  <div id={`${fieldIds.title}-error`} className="mt-1 text-xs text-rose-200" role="alert">
+                    {errors.title}
+                  </div>
+                ) : null}
+              </div>
+
+              <div>
+                <label htmlFor={fieldIds.type} className="text-sm font-medium text-slate-200">
+                  类型 <span className="text-rose-300">*</span>
+                </label>
+                <input
+                  id={fieldIds.type}
+                  name="type"
+                  className={fieldClasses(Boolean(errors.type))}
+                  value={values.type}
+                  onChange={(event) => updateField('type', event.target.value)}
+                  aria-invalid={Boolean(errors.type)}
+                  aria-describedby={errors.type ? `${fieldIds.type}-error` : undefined}
+                  placeholder="如：降雪、雷暴、洪水…"
+                  autoComplete="off"
+                />
+                {errors.type ? (
+                  <div id={`${fieldIds.type}-error`} className="mt-1 text-xs text-rose-200" role="alert">
+                    {errors.type}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              <div>
+                <label htmlFor={fieldIds.issued_at} className="text-sm font-medium text-slate-200">
+                  发布时间 <span className="text-rose-300">*</span>
+                </label>
+                <input
+                  id={fieldIds.issued_at}
+                  name="issued_at"
+                  type="datetime-local"
+                  className={fieldClasses(Boolean(errors.issued_at))}
+                  value={values.issued_at}
+                  onChange={(event) => updateField('issued_at', event.target.value)}
+                  aria-invalid={Boolean(errors.issued_at)}
+                  aria-describedby={errors.issued_at ? `${fieldIds.issued_at}-error` : undefined}
+                />
+                {errors.issued_at ? (
+                  <div id={`${fieldIds.issued_at}-error`} className="mt-1 text-xs text-rose-200" role="alert">
+                    {errors.issued_at}
+                  </div>
+                ) : null}
+              </div>
+
+              <div>
+                <label htmlFor={fieldIds.valid_from} className="text-sm font-medium text-slate-200">
+                  有效开始时间 <span className="text-rose-300">*</span>
+                </label>
+                <input
+                  id={fieldIds.valid_from}
+                  name="valid_from"
+                  type="datetime-local"
+                  className={fieldClasses(Boolean(errors.valid_from))}
+                  value={values.valid_from}
+                  onChange={(event) => updateField('valid_from', event.target.value)}
+                  aria-invalid={Boolean(errors.valid_from)}
+                  aria-describedby={errors.valid_from ? `${fieldIds.valid_from}-error` : undefined}
+                />
+                {errors.valid_from ? (
+                  <div id={`${fieldIds.valid_from}-error`} className="mt-1 text-xs text-rose-200" role="alert">
+                    {errors.valid_from}
+                  </div>
+                ) : null}
+              </div>
+
+              <div>
+                <label htmlFor={fieldIds.valid_to} className="text-sm font-medium text-slate-200">
+                  有效结束时间 <span className="text-rose-300">*</span>
+                </label>
+                <input
+                  id={fieldIds.valid_to}
+                  name="valid_to"
+                  type="datetime-local"
+                  className={fieldClasses(Boolean(errors.valid_to))}
+                  value={values.valid_to}
+                  onChange={(event) => updateField('valid_to', event.target.value)}
+                  aria-invalid={Boolean(errors.valid_to)}
+                  aria-describedby={errors.valid_to ? `${fieldIds.valid_to}-error` : undefined}
+                />
+                {errors.valid_to ? (
+                  <div id={`${fieldIds.valid_to}-error`} className="mt-1 text-xs text-rose-200" role="alert">
+                    {errors.valid_to}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label htmlFor={fieldIds.severity} className="text-sm font-medium text-slate-200">
+                  严重程度 <span className="text-slate-400">(可选)</span>
+                </label>
+                <select
+                  id={fieldIds.severity}
+                  name="severity"
+                  className={fieldClasses(Boolean(errors.severity))}
+                  value={values.severity}
+                  onChange={(event) => updateField('severity', event.target.value)}
+                  aria-invalid={Boolean(errors.severity)}
+                >
+                  <option value="">未设置</option>
+                  <option value="low">低</option>
+                  <option value="medium">中</option>
+                  <option value="high">高</option>
+                </select>
+                {errors.severity ? (
+                  <div className="mt-1 text-xs text-rose-200" role="alert">
+                    {errors.severity}
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="rounded-lg border border-slate-400/10 bg-slate-900/20 p-3 text-xs text-slate-400">
+                <div className="font-medium text-slate-200">校验规则</div>
+                <ul className="mt-1 list-disc space-y-1 pl-4">
+                  <li>必填字段不能为空</li>
+                  <li>有效开始时间需早于有效结束时间</li>
+                  <li>发布时间需早于或等于有效开始时间</li>
+                </ul>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor={fieldIds.text} className="text-sm font-medium text-slate-200">
+                正文 <span className="text-rose-300">*</span>
+              </label>
+              <textarea
+                id={fieldIds.text}
+                name="text"
+                className={[fieldClasses(Boolean(errors.text)), 'min-h-32 resize-y'].join(' ')}
+                value={values.text}
+                onChange={(event) => updateField('text', event.target.value)}
+                aria-invalid={Boolean(errors.text)}
+                aria-describedby={errors.text ? `${fieldIds.text}-error` : undefined}
+                placeholder="请输入正文内容"
+              />
+              {errors.text ? (
+                <div id={`${fieldIds.text}-error`} className="mt-1 text-xs text-rose-200" role="alert">
+                  {errors.text}
+                </div>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-end">
+              <button
+                type="button"
+                className="rounded-lg border border-slate-400/20 bg-slate-700/30 px-3 py-2 text-sm text-slate-200 hover:bg-slate-700/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                onClick={handleSaveDraft}
+              >
+                保存草稿
+              </button>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="rounded-lg border border-blue-400/30 bg-blue-500/20 px-3 py-2 text-sm font-medium text-blue-100 hover:bg-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+              >
+                {isSubmitting ? '提交中…' : '提交'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/features/products/productEditorValidation.test.ts
+++ b/apps/web/src/features/products/productEditorValidation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  datetimeLocalToIso,
+  isoToDatetimeLocal,
+  normalizeProductEditorValues,
+  validateProductEditor,
+} from './productEditorValidation';
+
+describe('productEditorValidation', () => {
+  it('converts datetime-local strings to ISO (UTC)', () => {
+    expect(datetimeLocalToIso('2026-01-01T00:00')).toBe('2026-01-01T00:00:00.000Z');
+    expect(datetimeLocalToIso('not-a-date')).toBeNull();
+  });
+
+  it('converts ISO strings to datetime-local (UTC)', () => {
+    expect(isoToDatetimeLocal('2026-01-01T00:00:00Z')).toBe('2026-01-01T00:00');
+    expect(isoToDatetimeLocal('not-a-date')).toBeNull();
+  });
+
+  it('normalizes datetime-local fields into ISO strings', () => {
+    const normalized = normalizeProductEditorValues({
+      title: '  Title  ',
+      type: ' snow ',
+      severity: '',
+      text: ' Body ',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T00:00',
+      valid_to: '2026-01-02T00:00',
+    });
+
+    expect(normalized).toEqual({
+      title: 'Title',
+      type: 'snow',
+      severity: '',
+      text: 'Body',
+      issued_at: '2026-01-01T00:00:00.000Z',
+      valid_from: '2026-01-01T00:00:00.000Z',
+      valid_to: '2026-01-02T00:00:00.000Z',
+    });
+  });
+
+  it('validates severity values', () => {
+    const errors = validateProductEditor({
+      title: 'Title',
+      type: 'snow',
+      severity: 'oops',
+      text: 'Body',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T00:00',
+      valid_to: '2026-01-02T00:00',
+    });
+
+    expect(errors.severity).toBe('严重程度必须为 low / medium / high 或留空');
+  });
+});
+

--- a/apps/web/src/features/products/productEditorValidation.ts
+++ b/apps/web/src/features/products/productEditorValidation.ts
@@ -1,0 +1,76 @@
+import type { ProductDraft } from '../../state/productDraft';
+
+export type ProductEditorValues = ProductDraft;
+
+export type ProductEditorErrors = Partial<Record<keyof ProductEditorValues, string>> & {
+  form?: string;
+};
+
+function normalizeText(value: string): string {
+  return value.trim();
+}
+
+function toEpochMs(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const date = new Date(trimmed);
+  const ms = date.getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+export function normalizeProductEditorValues(values: ProductEditorValues): ProductEditorValues {
+  return {
+    title: normalizeText(values.title),
+    text: normalizeText(values.text),
+    issued_at: normalizeText(values.issued_at),
+    valid_from: normalizeText(values.valid_from),
+    valid_to: normalizeText(values.valid_to),
+    type: normalizeText(values.type),
+    severity: normalizeText(values.severity),
+  };
+}
+
+export function validateProductEditor(values: ProductEditorValues): ProductEditorErrors {
+  const errors: ProductEditorErrors = {};
+
+  const required: Array<keyof ProductEditorValues> = [
+    'title',
+    'text',
+    'issued_at',
+    'valid_from',
+    'valid_to',
+    'type',
+  ];
+
+  for (const field of required) {
+    if (!normalizeText(values[field])) {
+      errors[field] = '此项为必填';
+    }
+  }
+
+  const issuedAtMs = toEpochMs(values.issued_at);
+  if (normalizeText(values.issued_at) && issuedAtMs == null) {
+    errors.issued_at = '请输入合法的时间';
+  }
+
+  const validFromMs = toEpochMs(values.valid_from);
+  if (normalizeText(values.valid_from) && validFromMs == null) {
+    errors.valid_from = '请输入合法的时间';
+  }
+
+  const validToMs = toEpochMs(values.valid_to);
+  if (normalizeText(values.valid_to) && validToMs == null) {
+    errors.valid_to = '请输入合法的时间';
+  }
+
+  if (validFromMs != null && validToMs != null && validFromMs >= validToMs) {
+    errors.valid_to = '结束时间必须晚于开始时间';
+  }
+
+  if (issuedAtMs != null && validFromMs != null && issuedAtMs > validFromMs) {
+    errors.issued_at = '发布时间需早于或等于有效开始时间';
+  }
+
+  return errors;
+}
+

--- a/apps/web/src/features/products/productEditorValidation.ts
+++ b/apps/web/src/features/products/productEditorValidation.ts
@@ -1,10 +1,111 @@
 import type { ProductDraft } from '../../state/productDraft';
 
+/**
+ * Form values for the product editor.
+ *
+ * Date fields are stored in the `datetime-local` format: `YYYY-MM-DDTHH:mm`.
+ * This project treats them as UTC timestamps when converting to/from ISO strings.
+ */
 export type ProductEditorValues = ProductDraft;
+
+/**
+ * Payload values after normalization.
+ *
+ * Date fields are ISO 8601 strings in UTC (e.g. `2026-01-01T00:00:00.000Z`).
+ */
+export type ProductEditorSubmitValues = Omit<ProductDraft, 'issued_at' | 'valid_from' | 'valid_to'> & {
+  issued_at: string;
+  valid_from: string;
+  valid_to: string;
+};
 
 export type ProductEditorErrors = Partial<Record<keyof ProductEditorValues, string>> & {
   form?: string;
 };
+
+type DateTimeLocalParts = {
+  year: number;
+  month: number;
+  day: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  milliseconds: number;
+};
+
+const DATETIME_LOCAL_RE =
+  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hours>\d{2}):(?<minutes>\d{2})(?::(?<seconds>\d{2})(?:\.(?<milliseconds>\d{1,3}))?)?$/;
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, '0');
+}
+
+function parseDateTimeLocalParts(value: string): DateTimeLocalParts | null {
+  const match = DATETIME_LOCAL_RE.exec(value);
+  if (!match?.groups) return null;
+
+  const year = Number(match.groups.year);
+  const month = Number(match.groups.month);
+  const day = Number(match.groups.day);
+  const hours = Number(match.groups.hours);
+  const minutes = Number(match.groups.minutes);
+  const seconds = match.groups.seconds ? Number(match.groups.seconds) : 0;
+  const milliseconds = match.groups.milliseconds ? Number(match.groups.milliseconds.padEnd(3, '0')) : 0;
+
+  if (![year, month, day, hours, minutes, seconds, milliseconds].every(Number.isFinite)) return null;
+
+  if (month < 1 || month > 12) return null;
+  if (hours < 0 || hours > 23) return null;
+  if (minutes < 0 || minutes > 59) return null;
+  if (seconds < 0 || seconds > 59) return null;
+  if (milliseconds < 0 || milliseconds > 999) return null;
+
+  const ms = Date.UTC(year, month - 1, day, hours, minutes, seconds, milliseconds);
+  const date = new Date(ms);
+  if (Number.isNaN(date.getTime())) return null;
+  if (date.getUTCFullYear() !== year) return null;
+  if (date.getUTCMonth() + 1 !== month) return null;
+  if (date.getUTCDate() !== day) return null;
+
+  return { year, month, day, hours, minutes, seconds, milliseconds };
+}
+
+function formatUtcDateTimeLocal(date: Date): string {
+  return [
+    `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())}`,
+    `${pad2(date.getUTCHours())}:${pad2(date.getUTCMinutes())}`,
+  ].join('T');
+}
+
+export function isoToDatetimeLocal(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) return null;
+  return formatUtcDateTimeLocal(date);
+}
+
+export function datetimeLocalToIso(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const parts = parseDateTimeLocalParts(trimmed);
+  if (!parts) return null;
+
+  const date = new Date(
+    Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hours,
+      parts.minutes,
+      parts.seconds,
+      parts.milliseconds,
+    ),
+  );
+
+  return date.toISOString();
+}
 
 function normalizeText(value: string): string {
   return value.trim();
@@ -13,18 +114,35 @@ function normalizeText(value: string): string {
 function toEpochMs(value: string): number | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
-  const date = new Date(trimmed);
-  const ms = date.getTime();
+
+  const dateTimeLocalParts = parseDateTimeLocalParts(trimmed);
+  if (dateTimeLocalParts) {
+    return Date.UTC(
+      dateTimeLocalParts.year,
+      dateTimeLocalParts.month - 1,
+      dateTimeLocalParts.day,
+      dateTimeLocalParts.hours,
+      dateTimeLocalParts.minutes,
+      dateTimeLocalParts.seconds,
+      dateTimeLocalParts.milliseconds,
+    );
+  }
+
+  const ms = new Date(trimmed).getTime();
   return Number.isNaN(ms) ? null : ms;
 }
 
-export function normalizeProductEditorValues(values: ProductEditorValues): ProductEditorValues {
+export function normalizeProductEditorValues(values: ProductEditorValues): ProductEditorSubmitValues {
+  const issuedAtIso = datetimeLocalToIso(values.issued_at);
+  const validFromIso = datetimeLocalToIso(values.valid_from);
+  const validToIso = datetimeLocalToIso(values.valid_to);
+
   return {
     title: normalizeText(values.title),
     text: normalizeText(values.text),
-    issued_at: normalizeText(values.issued_at),
-    valid_from: normalizeText(values.valid_from),
-    valid_to: normalizeText(values.valid_to),
+    issued_at: issuedAtIso ?? normalizeText(values.issued_at),
+    valid_from: validFromIso ?? normalizeText(values.valid_from),
+    valid_to: validToIso ?? normalizeText(values.valid_to),
     type: normalizeText(values.type),
     severity: normalizeText(values.severity),
   };
@@ -68,9 +186,13 @@ export function validateProductEditor(values: ProductEditorValues): ProductEdito
   }
 
   if (issuedAtMs != null && validFromMs != null && issuedAtMs > validFromMs) {
-    errors.issued_at = '发布时间需早于或等于有效开始时间';
+      errors.issued_at = '发布时间需早于或等于有效开始时间';
+  }
+
+  const severity = normalizeText(values.severity);
+  if (severity && severity !== 'low' && severity !== 'medium' && severity !== 'high') {
+    errors.severity = '严重程度必须为 low / medium / high 或留空';
   }
 
   return errors;
 }
-

--- a/apps/web/src/state/productDraft.test.ts
+++ b/apps/web/src/state/productDraft.test.ts
@@ -2,6 +2,8 @@ import { act, render, screen } from '@testing-library/react';
 import { createElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ProductDraft } from './productDraft';
+
 const STORAGE_KEY = 'digital-earth.productDraft';
 
 async function importFresh() {
@@ -189,7 +191,7 @@ describe('productDraft store', () => {
     const { useProductDraftStore } = await importFresh();
 
     expect(() => {
-      useProductDraftStore.getState().setDraft(null as unknown as any);
+      useProductDraftStore.getState().setDraft(null as unknown as ProductDraft);
     }).not.toThrow();
 
     expect(useProductDraftStore.getState().draft).toBeNull();

--- a/apps/web/src/state/productDraft.test.ts
+++ b/apps/web/src/state/productDraft.test.ts
@@ -1,0 +1,283 @@
+import { act, render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'digital-earth.productDraft';
+
+async function importFresh() {
+  vi.resetModules();
+  return await import('./productDraft');
+}
+
+function writeStorage(value: unknown) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+}
+
+describe('productDraft store', () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults to null when localStorage is empty', async () => {
+    const { useProductDraftStore } = await importFresh();
+    expect(useProductDraftStore.getState().draft).toBeNull();
+    expect(useProductDraftStore.getState().updatedAt).toBeNull();
+  });
+
+  it('ignores malformed JSON in localStorage', async () => {
+    localStorage.setItem(STORAGE_KEY, '{not-json');
+    const { useProductDraftStore } = await importFresh();
+    expect(useProductDraftStore.getState().draft).toBeNull();
+  });
+
+  it('restores a valid persisted draft', async () => {
+    writeStorage({
+      draft: {
+        title: 'T',
+        text: 'Body',
+        issued_at: '2026-01-01T00:00',
+        valid_from: '2026-01-01T01:00',
+        valid_to: '2026-01-01T02:00',
+        type: 'snow',
+        severity: 'low',
+      },
+      updatedAt: 123,
+    });
+
+    const { useProductDraftStore } = await importFresh();
+    expect(useProductDraftStore.getState().draft).toEqual({
+      title: 'T',
+      text: 'Body',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T01:00',
+      valid_to: '2026-01-01T02:00',
+      type: 'snow',
+      severity: 'low',
+    });
+    expect(useProductDraftStore.getState().updatedAt).toBe(123);
+  });
+
+  it('restores a draft and stamps updatedAt when missing', async () => {
+    writeStorage({
+      draft: {
+        title: 'T',
+        text: 'Body',
+        issued_at: '2026-01-01T00:00',
+        valid_from: '2026-01-01T01:00',
+        valid_to: '2026-01-01T02:00',
+        type: 'snow',
+        severity: '',
+      },
+      updatedAt: null,
+    });
+
+    const { useProductDraftStore } = await importFresh();
+    expect(useProductDraftStore.getState().draft?.title).toBe('T');
+    expect(useProductDraftStore.getState().updatedAt).toBe(new Date('2026-01-01T00:00:00Z').getTime());
+  });
+
+  it('accepts a legacy persisted payload', async () => {
+    writeStorage({
+      title: 'Legacy',
+      text: 'Body',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T01:00',
+      valid_to: '2026-01-01T02:00',
+      type: 'snow',
+      severity: '',
+    });
+
+    const { useProductDraftStore } = await importFresh();
+    expect(useProductDraftStore.getState().draft?.title).toBe('Legacy');
+    expect(useProductDraftStore.getState().updatedAt).toBeTypeOf('number');
+  });
+
+  it('setState clears the draft when draft=null', async () => {
+    const { useProductDraftStore } = await importFresh();
+
+    useProductDraftStore.getState().setDraft({
+      title: 'T',
+      text: 'Body',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T01:00',
+      valid_to: '2026-01-01T02:00',
+      type: 'snow',
+      severity: '',
+    });
+
+    useProductDraftStore.setState({ draft: null });
+    expect(useProductDraftStore.getState().draft).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('setState sets draft and persists', async () => {
+    const { useProductDraftStore } = await importFresh();
+
+    useProductDraftStore.setState({
+      draft: {
+        title: 'From setState',
+        text: 'Body',
+        issued_at: '2026-01-01T00:00',
+        valid_from: '2026-01-01T01:00',
+        valid_to: '2026-01-01T02:00',
+        type: 'snow',
+        severity: '',
+      },
+    });
+
+    expect(useProductDraftStore.getState().draft?.title).toBe('From setState');
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('setState updates updatedAt and persists', async () => {
+    const { useProductDraftStore } = await importFresh();
+
+    useProductDraftStore.getState().setDraft({
+      title: 'T',
+      text: 'Body',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T01:00',
+      valid_to: '2026-01-01T02:00',
+      type: 'snow',
+      severity: '',
+    });
+
+    useProductDraftStore.setState({ updatedAt: 999 });
+    expect(useProductDraftStore.getState().updatedAt).toBe(999);
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
+    expect(persisted).toMatchObject({ updatedAt: 999 });
+  });
+
+  it('setDraft updates state and persists', async () => {
+    const { useProductDraftStore } = await importFresh();
+
+    useProductDraftStore.getState().setDraft({
+      title: 'T',
+      text: 'Body',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T01:00',
+      valid_to: '2026-01-01T02:00',
+      type: 'snow',
+      severity: '',
+    });
+
+    expect(useProductDraftStore.getState().draft?.title).toBe('T');
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
+    expect(persisted).toEqual({
+      draft: {
+        title: 'T',
+        text: 'Body',
+        issued_at: '2026-01-01T00:00',
+        valid_from: '2026-01-01T01:00',
+        valid_to: '2026-01-01T02:00',
+        type: 'snow',
+        severity: '',
+      },
+      updatedAt: new Date('2026-01-01T00:00:00Z').getTime(),
+    });
+  });
+
+  it('setDraft ignores invalid payloads', async () => {
+    const { useProductDraftStore } = await importFresh();
+
+    expect(() => {
+      useProductDraftStore.getState().setDraft(null as unknown as any);
+    }).not.toThrow();
+
+    expect(useProductDraftStore.getState().draft).toBeNull();
+  });
+
+  it('clearDraft is a no-op when already cleared', async () => {
+    const { useProductDraftStore } = await importFresh();
+    expect(() => useProductDraftStore.getState().clearDraft()).not.toThrow();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('ignores localStorage write failures', async () => {
+    const { useProductDraftStore } = await importFresh();
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('blocked');
+      });
+
+    expect(() => {
+      useProductDraftStore.getState().setDraft({
+        title: 'T',
+        text: 'Body',
+        issued_at: '2026-01-01T00:00',
+        valid_from: '2026-01-01T01:00',
+        valid_to: '2026-01-01T02:00',
+        type: 'snow',
+        severity: '',
+      });
+    }).not.toThrow();
+
+    expect(useProductDraftStore.getState().draft?.title).toBe('T');
+    setItemSpy.mockRestore();
+  });
+
+  it('patchDraft creates a draft when empty and persists', async () => {
+    const { useProductDraftStore } = await importFresh();
+
+    useProductDraftStore.getState().patchDraft({ title: 'Patched', severity: 'high' });
+    expect(useProductDraftStore.getState().draft).toEqual({
+      title: 'Patched',
+      text: '',
+      issued_at: '',
+      valid_from: '',
+      valid_to: '',
+      type: '',
+      severity: 'high',
+    });
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
+    expect(persisted).toMatchObject({
+      draft: { title: 'Patched', severity: 'high' },
+    });
+  });
+
+  it('clearDraft removes persisted storage', async () => {
+    const { useProductDraftStore } = await importFresh();
+
+    useProductDraftStore.getState().setDraft({
+      title: 'T',
+      text: 'Body',
+      issued_at: '2026-01-01T00:00',
+      valid_from: '2026-01-01T01:00',
+      valid_to: '2026-01-01T02:00',
+      type: 'snow',
+      severity: '',
+    });
+
+    useProductDraftStore.getState().clearDraft();
+    expect(useProductDraftStore.getState().draft).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('useProductDraftStore subscribes via useSyncExternalStore', async () => {
+    const { useProductDraftStore } = await importFresh();
+
+    function DraftTitle() {
+      const draftTitle = useProductDraftStore((state) => state.draft?.title ?? 'none');
+      return createElement('div', { 'data-testid': 'title' }, draftTitle);
+    }
+
+    render(createElement(DraftTitle));
+    expect(screen.getByTestId('title')).toHaveTextContent('none');
+
+    act(() => {
+      useProductDraftStore.getState().patchDraft({ title: 'Updated' });
+    });
+
+    expect(screen.getByTestId('title')).toHaveTextContent('Updated');
+  });
+});

--- a/apps/web/src/state/productDraft.ts
+++ b/apps/web/src/state/productDraft.ts
@@ -1,0 +1,201 @@
+import { useSyncExternalStore } from 'react';
+
+export type ProductDraft = {
+  title: string;
+  text: string;
+  issued_at: string;
+  valid_from: string;
+  valid_to: string;
+  type: string;
+  /**
+   * Optional severity label for the product (e.g. "low" | "medium" | "high").
+   * An empty string means unset.
+   */
+  severity: string;
+};
+
+type PersistedProductDraft = {
+  draft: ProductDraft;
+  updatedAt: number;
+};
+
+type ProductDraftState = {
+  draft: ProductDraft | null;
+  updatedAt: number | null;
+  setDraft: (draft: ProductDraft) => void;
+  patchDraft: (draft: Partial<ProductDraft>) => void;
+  clearDraft: () => void;
+};
+
+const STORAGE_KEY = 'digital-earth.productDraft';
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+export function createEmptyProductDraft(): ProductDraft {
+  return {
+    title: '',
+    text: '',
+    issued_at: '',
+    valid_from: '',
+    valid_to: '',
+    type: '',
+    severity: '',
+  };
+}
+
+function parseProductDraft(value: unknown): ProductDraft | null {
+  if (!isRecord(value)) return null;
+
+  return {
+    title: normalizeString(value.title),
+    text: normalizeString(value.text),
+    issued_at: normalizeString(value.issued_at),
+    valid_from: normalizeString(value.valid_from),
+    valid_to: normalizeString(value.valid_to),
+    type: normalizeString(value.type),
+    severity: normalizeString(value.severity),
+  };
+}
+
+function parsePersistedProductDraft(value: unknown): PersistedProductDraft | null {
+  if (!isRecord(value)) return null;
+
+  const updatedAt = value.updatedAt;
+  const updatedAtNumber = typeof updatedAt === 'number' && Number.isFinite(updatedAt) ? updatedAt : null;
+
+  const draft = parseProductDraft(value.draft);
+  if (!draft) {
+    // Backwards-compatible: accept legacy payloads storing the draft directly.
+    const legacyDraft = parseProductDraft(value);
+    if (!legacyDraft) return null;
+    return { draft: legacyDraft, updatedAt: updatedAtNumber ?? Date.now() };
+  }
+
+  if (updatedAtNumber == null) return { draft, updatedAt: Date.now() };
+  return { draft, updatedAt: updatedAtNumber };
+}
+
+function safeReadPersistedDraft(): PersistedProductDraft | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    return parsePersistedProductDraft(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function safeWritePersistedDraft(value: PersistedProductDraft | null) {
+  try {
+    if (!value) {
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // ignore write failures (e.g., disabled storage)
+  }
+}
+
+let persisted = safeReadPersistedDraft();
+let draft: ProductDraft | null = persisted?.draft ?? null;
+let updatedAt: number | null = persisted?.updatedAt ?? null;
+
+function persist() {
+  if (!draft || updatedAt == null) {
+    safeWritePersistedDraft(null);
+    return;
+  }
+
+  safeWritePersistedDraft({ draft, updatedAt });
+}
+
+const setDraft: ProductDraftState['setDraft'] = (next) => {
+  const parsed = parseProductDraft(next);
+  if (!parsed) return;
+  draft = parsed;
+  updatedAt = Date.now();
+  persist();
+  notify();
+};
+
+const patchDraft: ProductDraftState['patchDraft'] = (patch) => {
+  const current = draft ?? createEmptyProductDraft();
+  draft = { ...current, ...patch };
+  updatedAt = Date.now();
+  persist();
+  notify();
+};
+
+const clearDraft: ProductDraftState['clearDraft'] = () => {
+  if (draft == null && updatedAt == null) return;
+  draft = null;
+  updatedAt = null;
+  persist();
+  notify();
+};
+
+function getState(): ProductDraftState {
+  return { draft, updatedAt, setDraft, patchDraft, clearDraft };
+}
+
+function setState(partial: Partial<Pick<ProductDraftState, 'draft' | 'updatedAt'>>) {
+  if ('draft' in partial) {
+    const nextDraft = partial.draft;
+    if (nextDraft == null) {
+      clearDraft();
+      return;
+    }
+    setDraft(nextDraft);
+    return;
+  }
+
+  if (typeof partial.updatedAt === 'number' && Number.isFinite(partial.updatedAt) && partial.updatedAt >= 0) {
+    updatedAt = partial.updatedAt;
+    persist();
+    notify();
+  }
+}
+
+function subscribe(listener: Listener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+type Selector<T> = (state: ProductDraftState) => T;
+
+type StoreHook = {
+  <T>(selector: Selector<T>): T;
+  getState: typeof getState;
+  setState: typeof setState;
+};
+
+const useProductDraftStoreImpl = <T>(selector: Selector<T>): T =>
+  useSyncExternalStore(
+    subscribe,
+    () => selector(getState()),
+    () => selector(getState()),
+  );
+
+export const useProductDraftStore: StoreHook = Object.assign(useProductDraftStoreImpl, {
+  getState,
+  setState,
+});

--- a/apps/web/src/state/productDraft.ts
+++ b/apps/web/src/state/productDraft.ts
@@ -113,7 +113,7 @@ function safeWritePersistedDraft(value: PersistedProductDraft | null) {
   }
 }
 
-let persisted = safeReadPersistedDraft();
+const persisted = safeReadPersistedDraft();
 let draft: ProductDraft | null = persisted?.draft ?? null;
 let updatedAt: number | null = persisted?.updatedAt ?? null;
 


### PR DESCRIPTION
## Summary
实现产品编辑器基础信息表单

## Changes
- 创建 ProductEditor 弹窗组件
- 表单字段：title/text/issued_at/valid_from/valid_to/type/severity
- 字段级验证：必填、时间范围、时间顺序
- 草稿保存到 localStorage (digital-earth.productDraft)
- 页面刷新后草稿持久化
- 明确区分"保存草稿"和"提交"按钮
- 复用 useModal hook (focus trap, Escape, overlay click)
- 完整单元测试覆盖 (>= 90%)

## Validation Rules
- Required fields: title, text, issued_at, valid_from, valid_to, type
- Time range: valid_from < valid_to
- Time order: issued_at <= valid_from

## Test Plan
- [x] 草稿读写测试
- [x] 模块重载后草稿仍在
- [x] 字段验证测试
- [x] 提交流程测试
- [x] 测试覆盖率 >= 90%
- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过

## Related Issues
Closes #97