### PR TITLE
[ST-0067] 产品编辑器 UI：绘制/编辑区域多边形 (#98)

### DIFF
--- a/apps/web/src/features/products/HazardPolygonMap.test.tsx
+++ b/apps/web/src/features/products/HazardPolygonMap.test.tsx
@@ -1,0 +1,357 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+type ScreenSpaceEventTypeMap = Record<string, string>;
+type Action = (movement: unknown) => void;
+
+type ViewerTestInstance = {
+  scene: {
+    pickPosition: ReturnType<typeof vi.fn>;
+    pick: ReturnType<typeof vi.fn>;
+  };
+  entities: { _entities: unknown[] };
+  __getAction: (type: string) => Action;
+  destroy: ReturnType<typeof vi.fn>;
+};
+
+type TestingApi = {
+  getLastViewer: () => unknown;
+  reset: () => void;
+  setImageryThrows: (value: boolean) => void;
+};
+
+type CesiumTestModule = {
+  ScreenSpaceEventType: ScreenSpaceEventTypeMap;
+  __testing: TestingApi;
+};
+
+vi.mock('cesium', () => {
+  const viewerInstances: unknown[] = [];
+  let imageryThrows = false;
+
+  class Color {
+    private name: string;
+
+    constructor(name: string) {
+      this.name = name;
+    }
+
+    withAlpha(alpha: number) {
+      void alpha;
+      return new Color(this.name);
+    }
+
+    static CYAN = new Color('CYAN');
+    static WHITE = new Color('WHITE');
+    static BLACK = new Color('BLACK');
+  }
+
+  class EllipsoidTerrainProvider {}
+
+  class PolygonHierarchy {
+    positions: unknown[];
+
+    constructor(positions: unknown[]) {
+      this.positions = positions;
+    }
+  }
+
+  const ScreenSpaceEventType = {
+    LEFT_DOWN: 'LEFT_DOWN',
+    LEFT_UP: 'LEFT_UP',
+    MOUSE_MOVE: 'MOUSE_MOVE',
+    LEFT_CLICK: 'LEFT_CLICK',
+    LEFT_DOUBLE_CLICK: 'LEFT_DOUBLE_CLICK',
+    RIGHT_CLICK: 'RIGHT_CLICK',
+  } as const;
+
+  const CesiumMath = {
+    toDegrees: (radians: number) => (radians * 180) / Math.PI,
+  };
+
+  const Cartesian3 = {
+    fromDegrees: (lon: number, lat: number, height?: number) => ({ lon, lat, height }),
+  };
+
+  const Cartographic = {
+    fromCartesian: (cartesian: { longitude?: number; latitude?: number }) => ({
+      longitude: cartesian.longitude ?? 0,
+      latitude: cartesian.latitude ?? 0,
+    }),
+  };
+
+  class UrlTemplateImageryProvider {
+    constructor(...args: unknown[]) {
+      void args;
+    }
+  }
+
+  class WebMercatorTilingScheme {
+    constructor(...args: unknown[]) {
+      void args;
+    }
+  }
+
+  class Viewer {
+    canvas = {};
+    imageryLayers = {
+      addImageryProvider: vi.fn(() => {
+        if (imageryThrows) throw new Error('imagery blocked');
+      }),
+    };
+    camera = {
+      setView: vi.fn(),
+      pickEllipsoid: vi.fn(() => null),
+    };
+    entities = {
+      _entities: [] as unknown[],
+      add: (entity: unknown) => {
+        this.entities._entities.push(entity);
+        return entity;
+      },
+      remove: vi.fn((entity: unknown) => {
+        this.entities._entities = this.entities._entities.filter((entry) => entry !== entity);
+      }),
+    };
+    scene = {
+      pickPosition: vi.fn(() => null),
+      pick: vi.fn(() => null),
+      globe: { ellipsoid: {} },
+      screenSpaceCameraController: {
+        enableRotate: true,
+        enableTranslate: true,
+      },
+    };
+    screenSpaceEventHandler = {
+      setInputAction: (cb: Action, type: string) => {
+        this.actions.set(type, cb);
+      },
+      removeInputAction: (type: string) => {
+        this.actions.delete(type);
+      },
+    };
+
+    private actions = new Map<string, Action>();
+    resize = vi.fn();
+    destroy = vi.fn();
+
+    constructor(...args: unknown[]) {
+      void args;
+      viewerInstances.push(this);
+    }
+
+    __getAction(type: string): Action {
+      const action = this.actions.get(type);
+      if (!action) throw new Error(`Missing action: ${type}`);
+      return action;
+    }
+  }
+
+  return {
+    Cartesian3,
+    Cartographic,
+    Color,
+    EllipsoidTerrainProvider,
+    Math: CesiumMath,
+    PolygonHierarchy,
+    ScreenSpaceEventType,
+    UrlTemplateImageryProvider,
+    Viewer,
+    WebMercatorTilingScheme,
+    __testing: {
+      getLastViewer: () => viewerInstances.at(-1) ?? null,
+      reset: () => {
+        viewerInstances.length = 0;
+        imageryThrows = false;
+      },
+      setImageryThrows: (value: boolean) => {
+        imageryThrows = value;
+      },
+    },
+  };
+});
+
+import * as Cesium from 'cesium';
+
+import { HazardPolygonMap } from './HazardPolygonMap';
+
+function degreesToRadians(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+function getCesiumModule(): CesiumTestModule {
+  return Cesium as unknown as CesiumTestModule;
+}
+
+async function getViewerInstance(): Promise<ViewerTestInstance> {
+  const { __testing } = getCesiumModule();
+
+  return await waitFor(() => {
+    const instance = __testing.getLastViewer();
+    expect(instance).toBeTruthy();
+    return instance as ViewerTestInstance;
+  });
+}
+
+describe('HazardPolygonMap', () => {
+  it('adds vertices on click while drawing', async () => {
+    const { __testing, ScreenSpaceEventType } = getCesiumModule();
+    __testing.reset();
+    const onChangeVertices = vi.fn();
+
+    render(
+      <HazardPolygonMap
+        hazards={[{ id: 'h1', vertices: [] }]}
+        activeHazardId="h1"
+        drawing
+        onSetActiveHazardId={vi.fn()}
+        onChangeVertices={onChangeVertices}
+        onDeleteVertex={vi.fn()}
+        onFinishDrawing={vi.fn()}
+      />,
+    );
+
+    const viewer = await getViewerInstance();
+    viewer.scene.pickPosition.mockReturnValue({
+      longitude: degreesToRadians(10),
+      latitude: degreesToRadians(20),
+    });
+
+    viewer.__getAction(ScreenSpaceEventType.LEFT_CLICK)({ position: { x: 1, y: 2 } });
+
+    expect(onChangeVertices).toHaveBeenCalledWith('h1', [{ lon: 10, lat: 20 }]);
+  });
+
+  it('selects a hazard polygon on click while idle', async () => {
+    const { __testing, ScreenSpaceEventType } = getCesiumModule();
+    __testing.reset();
+    const onSetActiveHazardId = vi.fn();
+
+    render(
+      <HazardPolygonMap
+        hazards={[
+          {
+            id: 'h1',
+            vertices: [
+              { lon: 0, lat: 0 },
+              { lon: 1, lat: 0 },
+              { lon: 1, lat: 1 },
+            ],
+          },
+        ]}
+        activeHazardId={null}
+        drawing={false}
+        onSetActiveHazardId={onSetActiveHazardId}
+        onChangeVertices={vi.fn()}
+        onDeleteVertex={vi.fn()}
+        onFinishDrawing={vi.fn()}
+      />,
+    );
+
+    const viewer = await getViewerInstance();
+    expect(viewer.entities._entities.length).toBeGreaterThan(0);
+
+    const polygonEntity = viewer.entities._entities.find((entity) => {
+      return (
+        (entity as { __hazardPolygon?: { hazardId?: string } }).__hazardPolygon?.hazardId === 'h1'
+      );
+    });
+    expect(polygonEntity).toBeTruthy();
+
+    viewer.scene.pick.mockReturnValue({ id: polygonEntity });
+    viewer.__getAction(ScreenSpaceEventType.LEFT_CLICK)({ position: { x: 3, y: 4 } });
+
+    expect(onSetActiveHazardId).toHaveBeenCalledWith('h1');
+  });
+
+  it('drags and deletes vertices', async () => {
+    const { __testing, ScreenSpaceEventType } = getCesiumModule();
+    __testing.reset();
+    const onChangeVertices = vi.fn();
+    const onDeleteVertex = vi.fn();
+
+    render(
+      <HazardPolygonMap
+        hazards={[{ id: 'h1', vertices: [{ lon: 0, lat: 0 }] }]}
+        activeHazardId="h1"
+        drawing={false}
+        onSetActiveHazardId={vi.fn()}
+        onChangeVertices={onChangeVertices}
+        onDeleteVertex={onDeleteVertex}
+        onFinishDrawing={vi.fn()}
+      />,
+    );
+
+    const viewer = await getViewerInstance();
+
+    const vertexEntity = viewer.entities._entities.find((entity) => {
+      return (
+        (entity as { __hazardVertex?: { hazardId?: string } }).__hazardVertex?.hazardId === 'h1'
+      );
+    });
+    expect(vertexEntity).toBeTruthy();
+
+    viewer.scene.pick.mockReturnValue({ id: vertexEntity });
+    viewer.scene.pickPosition.mockReturnValue({
+      longitude: degreesToRadians(2),
+      latitude: degreesToRadians(3),
+    });
+
+    viewer.__getAction(ScreenSpaceEventType.LEFT_DOWN)({ position: { x: 10, y: 10 } });
+    viewer.__getAction(ScreenSpaceEventType.MOUSE_MOVE)({ endPosition: { x: 11, y: 11 } });
+    viewer.__getAction(ScreenSpaceEventType.LEFT_UP)({});
+
+    expect(onChangeVertices).toHaveBeenCalledWith('h1', [{ lon: 2, lat: 3 }]);
+
+    viewer.__getAction(ScreenSpaceEventType.RIGHT_CLICK)({ position: { x: 10, y: 10 } });
+    expect(onDeleteVertex).toHaveBeenCalledWith('h1', 0);
+
+    // The click immediately after dragging should be ignored.
+    viewer.__getAction(ScreenSpaceEventType.LEFT_CLICK)({ position: { x: 10, y: 10 } });
+    expect(onChangeVertices).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes drawing on double click', async () => {
+    const { __testing, ScreenSpaceEventType } = getCesiumModule();
+    __testing.reset();
+    const onFinishDrawing = vi.fn();
+
+    render(
+      <HazardPolygonMap
+        hazards={[{ id: 'h1', vertices: [] }]}
+        activeHazardId="h1"
+        drawing
+        onSetActiveHazardId={vi.fn()}
+        onChangeVertices={vi.fn()}
+        onDeleteVertex={vi.fn()}
+        onFinishDrawing={onFinishDrawing}
+      />,
+    );
+
+    const viewer = await getViewerInstance();
+    viewer.__getAction(ScreenSpaceEventType.LEFT_DOUBLE_CLICK)({});
+    expect(onFinishDrawing).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores imagery failures and destroys the viewer on unmount', async () => {
+    const { __testing } = getCesiumModule();
+    __testing.reset();
+    __testing.setImageryThrows(true);
+
+    const { unmount } = render(
+      <HazardPolygonMap
+        hazards={[{ id: 'h1', vertices: [] }]}
+        activeHazardId="h1"
+        drawing={false}
+        onSetActiveHazardId={vi.fn()}
+        onChangeVertices={vi.fn()}
+        onDeleteVertex={vi.fn()}
+        onFinishDrawing={vi.fn()}
+      />,
+    );
+
+    const viewer = await getViewerInstance();
+    unmount();
+    expect(viewer.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/products/HazardPolygonMap.tsx
+++ b/apps/web/src/features/products/HazardPolygonMap.tsx
@@ -1,0 +1,399 @@
+import {
+  Cartesian3,
+  Cartographic,
+  Color,
+  EllipsoidTerrainProvider,
+  Math as CesiumMath,
+  PolygonHierarchy,
+  ScreenSpaceEventType,
+  UrlTemplateImageryProvider,
+  Viewer,
+  WebMercatorTilingScheme,
+} from 'cesium';
+import { useEffect, useRef } from 'react';
+
+import type { LonLat } from '../../lib/geo';
+
+type Hazard = { id: string; vertices: LonLat[] };
+
+type Movement = { position?: unknown; endPosition?: unknown };
+
+type PickResult = { id?: unknown };
+
+type HazardPolygonEntity = { __hazardPolygon?: { hazardId: string } };
+type HazardVertexEntity = { __hazardVertex?: { hazardId: string; index: number } };
+
+function pickEntity(picked: unknown): (HazardPolygonEntity & HazardVertexEntity) | null {
+  if (!picked || typeof picked !== 'object') return null;
+  const id = (picked as PickResult).id;
+  if (!id || typeof id !== 'object') return null;
+  return id as HazardPolygonEntity & HazardVertexEntity;
+}
+
+function pickLonLat(viewer: Viewer, position: unknown): LonLat | null {
+  const cartesian =
+    (viewer.scene as unknown as { pickPosition?: (pos: unknown) => unknown }).pickPosition?.(position) ??
+    (viewer.camera as unknown as { pickEllipsoid?: (pos: unknown, ellipsoid?: unknown) => unknown }).pickEllipsoid?.(
+      position,
+      (viewer.scene as unknown as { globe?: { ellipsoid?: unknown } }).globe?.ellipsoid,
+    );
+
+  if (!cartesian) return null;
+
+  const cartographic = Cartographic.fromCartesian(cartesian as never) as Cartographic;
+  const lon = CesiumMath.toDegrees(cartographic.longitude);
+  const lat = CesiumMath.toDegrees(cartographic.latitude);
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) return null;
+  return { lon, lat };
+}
+
+function setCameraInteractionEnabled(viewer: Viewer, enabled: boolean) {
+  const controller = viewer.scene.screenSpaceCameraController as unknown as {
+    enableRotate?: boolean;
+    enableTranslate?: boolean;
+  };
+  if (typeof controller.enableRotate === 'boolean') controller.enableRotate = enabled;
+  if (typeof controller.enableTranslate === 'boolean') controller.enableTranslate = enabled;
+}
+
+type EntitiesByHazardId = Map<
+  string,
+  {
+    polygon: unknown;
+    vertices: unknown[];
+  }
+>;
+
+function syncHazardEntities(options: {
+  viewer: Viewer;
+  hazards: Hazard[];
+  activeHazardId: string | null;
+  entitiesByHazardId: EntitiesByHazardId;
+}) {
+  const { viewer, hazards, activeHazardId, entitiesByHazardId } = options;
+
+  const activeFill = Color.CYAN.withAlpha(0.3);
+  const activeOutline = Color.CYAN.withAlpha(0.95);
+  const inactiveFill = Color.CYAN.withAlpha(0.12);
+  const inactiveOutline = Color.CYAN.withAlpha(0.35);
+
+  const nextIds = new Set(hazards.map((hazard) => hazard.id));
+  for (const [hazardId, entry] of entitiesByHazardId.entries()) {
+    if (nextIds.has(hazardId)) continue;
+    (viewer.entities as unknown as { remove?: (entity: unknown) => void }).remove?.(entry.polygon);
+    for (const entity of entry.vertices) {
+      (viewer.entities as unknown as { remove?: (entity: unknown) => void }).remove?.(entity);
+    }
+    entitiesByHazardId.delete(hazardId);
+  }
+
+  for (const hazard of hazards) {
+    const isActive = hazard.id === activeHazardId;
+    const style = {
+      fill: isActive ? activeFill : inactiveFill,
+      outline: isActive ? activeOutline : inactiveOutline,
+    };
+
+    let entry = entitiesByHazardId.get(hazard.id);
+    if (!entry) {
+      const polygon = viewer.entities.add({
+        id: `hazard-polygon:${hazard.id}`,
+        polygon: {
+          hierarchy: new PolygonHierarchy([]),
+          material: style.fill,
+          outline: true,
+          outlineColor: style.outline,
+        },
+      });
+      (polygon as unknown as HazardPolygonEntity).__hazardPolygon = { hazardId: hazard.id };
+      entry = { polygon, vertices: [] };
+      entitiesByHazardId.set(hazard.id, entry);
+    }
+
+    const polygonGraphics = (entry.polygon as { polygon?: unknown }).polygon as
+      | {
+          hierarchy?: unknown;
+          material?: unknown;
+          outline?: unknown;
+          outlineColor?: unknown;
+          show?: unknown;
+        }
+      | undefined;
+
+    const positions = hazard.vertices.map((vertex) => Cartesian3.fromDegrees(vertex.lon, vertex.lat));
+    if (polygonGraphics) {
+      polygonGraphics.hierarchy = new PolygonHierarchy(positions);
+      polygonGraphics.material = style.fill;
+      polygonGraphics.outline = true;
+      polygonGraphics.outlineColor = style.outline;
+      polygonGraphics.show = hazard.vertices.length >= 3;
+    }
+
+    while (entry.vertices.length < hazard.vertices.length) {
+      const index = entry.vertices.length;
+      const vertex = hazard.vertices[index] ?? { lon: 0, lat: 0 };
+      const entity = viewer.entities.add({
+        id: `hazard-vertex:${hazard.id}:${index}`,
+        position: Cartesian3.fromDegrees(vertex.lon, vertex.lat),
+        point: {
+          pixelSize: 10,
+          color: Color.WHITE.withAlpha(0.95),
+          outlineColor: Color.BLACK.withAlpha(0.6),
+          outlineWidth: 2,
+        },
+        show: isActive,
+      });
+      (entity as unknown as HazardVertexEntity).__hazardVertex = { hazardId: hazard.id, index };
+      entry.vertices.push(entity);
+    }
+
+    while (entry.vertices.length > hazard.vertices.length) {
+      const removed = entry.vertices.pop();
+      if (removed) (viewer.entities as unknown as { remove?: (entity: unknown) => void }).remove?.(removed);
+    }
+
+    for (let index = 0; index < entry.vertices.length; index += 1) {
+      const vertexEntity = entry.vertices[index] as {
+        position?: unknown;
+        show?: unknown;
+        __hazardVertex?: { hazardId: string; index: number };
+      };
+      const vertex = hazard.vertices[index]!;
+      vertexEntity.position = Cartesian3.fromDegrees(vertex.lon, vertex.lat);
+      vertexEntity.show = isActive;
+      if (vertexEntity.__hazardVertex) {
+        vertexEntity.__hazardVertex.hazardId = hazard.id;
+        vertexEntity.__hazardVertex.index = index;
+      } else {
+        vertexEntity.__hazardVertex = { hazardId: hazard.id, index };
+      }
+    }
+  }
+}
+
+type Props = {
+  hazards: Hazard[];
+  activeHazardId: string | null;
+  drawing: boolean;
+  onSetActiveHazardId: (hazardId: string | null) => void;
+  onChangeVertices: (hazardId: string, vertices: LonLat[]) => void;
+  onDeleteVertex: (hazardId: string, vertexIndex: number) => void;
+  onFinishDrawing: () => void;
+};
+
+export function HazardPolygonMap({
+  hazards,
+  activeHazardId,
+  drawing,
+  onSetActiveHazardId,
+  onChangeVertices,
+  onDeleteVertex,
+  onFinishDrawing,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const viewerRef = useRef<Viewer | null>(null);
+  const entitiesByHazardIdRef = useRef<EntitiesByHazardId>(new Map());
+  const hazardsRef = useRef<Hazard[]>(hazards);
+  const drawingRef = useRef<boolean>(drawing);
+  const activeHazardIdRef = useRef<string | null>(activeHazardId);
+  const callbacksRef = useRef({
+    onSetActiveHazardId,
+    onChangeVertices,
+    onDeleteVertex,
+    onFinishDrawing,
+  });
+  const draggingRef = useRef<{ hazardId: string; vertexIndex: number } | null>(null);
+  const ignoreNextClickRef = useRef(false);
+
+  useEffect(() => {
+    hazardsRef.current = hazards;
+  }, [hazards]);
+
+  useEffect(() => {
+    drawingRef.current = drawing;
+  }, [drawing]);
+
+  useEffect(() => {
+    activeHazardIdRef.current = activeHazardId;
+  }, [activeHazardId]);
+
+  useEffect(() => {
+    callbacksRef.current = { onSetActiveHazardId, onChangeVertices, onDeleteVertex, onFinishDrawing };
+  }, [onChangeVertices, onDeleteVertex, onFinishDrawing, onSetActiveHazardId]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const entitiesByHazardId = entitiesByHazardIdRef.current;
+
+    const viewer = new Viewer(container, {
+      animation: false,
+      baseLayerPicker: false,
+      fullscreenButton: false,
+      geocoder: false,
+      homeButton: false,
+      infoBox: false,
+      navigationHelpButton: false,
+      sceneModePicker: false,
+      selectionIndicator: false,
+      timeline: false,
+      terrainProvider: new EllipsoidTerrainProvider(),
+    });
+    viewerRef.current = viewer;
+
+    try {
+      viewer.imageryLayers.addImageryProvider(
+        new UrlTemplateImageryProvider({
+          url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+          tilingScheme: new WebMercatorTilingScheme(),
+        }),
+      );
+    } catch {
+      // ignore imagery failures
+    }
+
+    viewer.camera.setView({
+      destination: Cartesian3.fromDegrees(116.391, 39.9075, 20_000_000),
+    });
+
+    const handler = viewer.screenSpaceEventHandler as unknown as {
+      setInputAction?: (cb: (movement: Movement) => void, type: unknown) => void;
+      removeInputAction?: (type: unknown) => void;
+    };
+
+    const pickHazardVertex = (position: unknown): { hazardId: string; index: number } | null => {
+      const pickedObject = (viewer.scene as unknown as { pick?: (pos: unknown) => unknown }).pick?.(position);
+      const entity = pickEntity(pickedObject);
+      const metadata = entity?.__hazardVertex;
+      if (!metadata) return null;
+      return { hazardId: metadata.hazardId, index: metadata.index };
+    };
+
+    const pickHazardPolygon = (position: unknown): string | null => {
+      const pickedObject = (viewer.scene as unknown as { pick?: (pos: unknown) => unknown }).pick?.(position);
+      const entity = pickEntity(pickedObject);
+      return entity?.__hazardPolygon?.hazardId ?? entity?.__hazardVertex?.hazardId ?? null;
+    };
+
+    const onLeftDown = (movement: Movement) => {
+      const position = movement.position;
+      if (!position) return;
+
+      const activeId = activeHazardIdRef.current;
+      const picked = pickHazardVertex(position);
+      if (!activeId || !picked || picked.hazardId !== activeId) return;
+      draggingRef.current = { hazardId: picked.hazardId, vertexIndex: picked.index };
+      ignoreNextClickRef.current = true;
+      setCameraInteractionEnabled(viewer, false);
+    };
+
+    const onMouseMove = (movement: Movement) => {
+      const drag = draggingRef.current;
+      if (!drag) return;
+
+      const position = movement.endPosition;
+      if (!position) return;
+
+      const nextPoint = pickLonLat(viewer, position);
+      if (!nextPoint) return;
+
+      const hazards = hazardsRef.current;
+      const hazard = hazards.find((entry) => entry.id === drag.hazardId);
+      if (!hazard) return;
+
+      const nextVertices = hazard.vertices.map((vertex, index) =>
+        index === drag.vertexIndex ? nextPoint : vertex,
+      );
+      callbacksRef.current.onChangeVertices(drag.hazardId, nextVertices);
+    };
+
+    const onLeftUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = null;
+      setCameraInteractionEnabled(viewer, true);
+    };
+
+    const onRightClick = (movement: Movement) => {
+      const position = movement.position;
+      if (!position) return;
+      const picked = pickHazardVertex(position);
+      if (!picked) return;
+      callbacksRef.current.onDeleteVertex(picked.hazardId, picked.index);
+    };
+
+    const onLeftClick = (movement: Movement) => {
+      const position = movement.position;
+      if (!position) return;
+
+      if (ignoreNextClickRef.current) {
+        ignoreNextClickRef.current = false;
+        return;
+      }
+
+      const hazardId = activeHazardIdRef.current;
+      const isDrawing = drawingRef.current;
+
+      if (!isDrawing) {
+        const pickedHazardId = pickHazardPolygon(position);
+        if (pickedHazardId) callbacksRef.current.onSetActiveHazardId(pickedHazardId);
+        return;
+      }
+
+      if (!hazardId) return;
+
+      const picked = pickLonLat(viewer, position);
+      if (!picked) return;
+
+      const hazard = hazardsRef.current.find((entry) => entry.id === hazardId);
+      if (!hazard) return;
+
+      callbacksRef.current.onChangeVertices(hazardId, [...hazard.vertices, picked]);
+    };
+
+    const onDoubleClick = () => {
+      if (!drawingRef.current) return;
+      callbacksRef.current.onFinishDrawing();
+    };
+
+    handler.setInputAction?.(onLeftDown, ScreenSpaceEventType.LEFT_DOWN);
+    handler.setInputAction?.(onLeftUp, ScreenSpaceEventType.LEFT_UP);
+    handler.setInputAction?.(onMouseMove, ScreenSpaceEventType.MOUSE_MOVE);
+    handler.setInputAction?.(onLeftClick, ScreenSpaceEventType.LEFT_CLICK);
+    handler.setInputAction?.(onDoubleClick, ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
+    handler.setInputAction?.(onRightClick, ScreenSpaceEventType.RIGHT_CLICK);
+
+    const observer = new ResizeObserver(() => viewer.resize());
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      handler.removeInputAction?.(ScreenSpaceEventType.LEFT_DOWN);
+      handler.removeInputAction?.(ScreenSpaceEventType.LEFT_UP);
+      handler.removeInputAction?.(ScreenSpaceEventType.MOUSE_MOVE);
+      handler.removeInputAction?.(ScreenSpaceEventType.LEFT_CLICK);
+      handler.removeInputAction?.(ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
+      handler.removeInputAction?.(ScreenSpaceEventType.RIGHT_CLICK);
+      viewerRef.current = null;
+      entitiesByHazardId.clear();
+      viewer.destroy();
+    };
+  }, []);
+
+  useEffect(() => {
+    const viewer = viewerRef.current;
+    if (!viewer) return;
+    syncHazardEntities({
+      viewer,
+      hazards,
+      activeHazardId,
+      entitiesByHazardId: entitiesByHazardIdRef.current,
+    });
+  }, [activeHazardId, hazards]);
+
+  return (
+    <div className="w-full overflow-hidden rounded-lg border border-slate-400/20 bg-slate-950/20">
+      <div ref={containerRef} className="h-72 w-full" data-testid="hazard-polygon-map" />
+    </div>
+  );
+}

--- a/apps/web/src/features/products/ProductEditor.test.tsx
+++ b/apps/web/src/features/products/ProductEditor.test.tsx
@@ -2,12 +2,24 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+vi.mock('./HazardPolygonMap', () => ({
+  HazardPolygonMap: () => <div data-testid="hazard-polygon-map-mock" />,
+}));
+
 const NEW_STORAGE_KEY = 'digital-earth.productDraft.new';
 const PRODUCT_STORAGE_KEY = 'digital-earth.productDraft.1';
 
 async function importFreshEditor() {
   vi.resetModules();
   return await import('./ProductEditor');
+}
+
+async function addValidHazard(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: '新增区域' }));
+  // Add 3 vertices via the coordinate editor (defaults to 0/0 values).
+  await user.click(screen.getByRole('button', { name: '添加顶点' }));
+  await user.click(screen.getByRole('button', { name: '添加顶点' }));
+  await user.click(screen.getByRole('button', { name: '添加顶点' }));
 }
 
 describe('ProductEditor', () => {
@@ -22,6 +34,7 @@ describe('ProductEditor', () => {
       issued_at: 'not-a-date',
       valid_from: 'still-not-a-date',
       valid_to: 'nope',
+      hazards: [],
     });
 
     expect(errors.issued_at).toBe('请输入合法的时间');
@@ -42,6 +55,7 @@ describe('ProductEditor', () => {
 
     expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.getAllByText('此项为必填')).toHaveLength(6);
+    expect(screen.getByText('请至少添加一个风险区域')).toBeInTheDocument();
   });
 
   it('validates time ordering rules', async () => {
@@ -57,6 +71,8 @@ describe('ProductEditor', () => {
     await user.type(screen.getByLabelText(/标题/), '测试产品');
     await user.type(screen.getByLabelText(/类型/), '降雪');
     await user.type(screen.getByLabelText(/正文/), '这里是正文');
+
+    await addValidHazard(user);
 
     await user.type(screen.getByLabelText(/发布时间/), '2026-01-01T03:00');
     await user.type(screen.getByLabelText(/有效开始时间/), '2026-01-01T02:00');
@@ -89,6 +105,18 @@ describe('ProductEditor', () => {
     await user.type(screen.getByLabelText(/有效开始时间/), '2026-01-01T00:00');
     await user.type(screen.getByLabelText(/有效结束时间/), '2026-01-02T00:00');
 
+    await user.click(screen.getByRole('button', { name: '新增区域' }));
+    await user.click(screen.getByRole('button', { name: '添加顶点' }));
+    await user.click(screen.getByRole('button', { name: '添加顶点' }));
+    await user.click(screen.getByRole('button', { name: '添加顶点' }));
+
+    await user.clear(screen.getByLabelText('顶点 2 经度'));
+    await user.type(screen.getByLabelText('顶点 2 经度'), '1');
+    await user.clear(screen.getByLabelText('顶点 3 经度'));
+    await user.type(screen.getByLabelText('顶点 3 经度'), '1');
+    await user.clear(screen.getByLabelText('顶点 3 纬度'));
+    await user.type(screen.getByLabelText('顶点 3 纬度'), '1');
+
     await user.click(screen.getByRole('button', { name: '保存草稿' }));
     expect(screen.getByText('草稿已保存')).toBeInTheDocument();
     expect(localStorage.getItem(NEW_STORAGE_KEY)).not.toBeNull();
@@ -107,6 +135,13 @@ describe('ProductEditor', () => {
       issued_at: '2026-01-01T00:00:00.000Z',
       valid_from: '2026-01-01T00:00:00.000Z',
       valid_to: '2026-01-02T00:00:00.000Z',
+      hazards: [
+        expect.objectContaining({
+          geometry: expect.any(Object),
+          bbox: { min_x: 0, min_y: 0, max_x: 1, max_y: 1 },
+          area_km2: expect.any(Number),
+        }),
+      ],
     });
 
     await waitFor(() => {
@@ -181,6 +216,7 @@ describe('ProductEditor', () => {
           issued_at: '2026-01-01T00:00',
           valid_from: '2026-01-01T01:00',
           valid_to: '2026-01-01T02:00',
+          hazards: [],
         },
         updatedAt: 123,
       }),
@@ -200,6 +236,7 @@ describe('ProductEditor', () => {
           issued_at: '2026-01-01T00:00:00Z',
           valid_from: '2026-01-01T01:00:00Z',
           valid_to: '2026-01-01T02:00:00Z',
+          hazards: [],
         }}
         onClose={() => {}}
         onSubmit={() => {}}
@@ -235,6 +272,8 @@ describe('ProductEditor', () => {
     await user.type(screen.getByLabelText(/发布时间/), '2026-01-01T00:00');
     await user.type(screen.getByLabelText(/有效开始时间/), '2026-01-01T00:00');
     await user.type(screen.getByLabelText(/有效结束时间/), '2026-01-02T00:00');
+
+    await addValidHazard(user);
 
     await user.click(screen.getByRole('button', { name: '提交' }));
 

--- a/apps/web/src/features/products/ProductEditor.test.tsx
+++ b/apps/web/src/features/products/ProductEditor.test.tsx
@@ -16,10 +16,25 @@ async function importFreshEditor() {
 
 async function addValidHazard(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: '新增区域' }));
-  // Add 3 vertices via the coordinate editor (defaults to 0/0 values).
+  // Add 3 vertices via the coordinate editor and make them non-degenerate.
   await user.click(screen.getByRole('button', { name: '添加顶点' }));
   await user.click(screen.getByRole('button', { name: '添加顶点' }));
   await user.click(screen.getByRole('button', { name: '添加顶点' }));
+
+  await user.clear(screen.getByLabelText('顶点 1 经度'));
+  await user.type(screen.getByLabelText('顶点 1 经度'), '0');
+  await user.clear(screen.getByLabelText('顶点 1 纬度'));
+  await user.type(screen.getByLabelText('顶点 1 纬度'), '0');
+
+  await user.clear(screen.getByLabelText('顶点 2 经度'));
+  await user.type(screen.getByLabelText('顶点 2 经度'), '0.002');
+  await user.clear(screen.getByLabelText('顶点 2 纬度'));
+  await user.type(screen.getByLabelText('顶点 2 纬度'), '0');
+
+  await user.clear(screen.getByLabelText('顶点 3 经度'));
+  await user.type(screen.getByLabelText('顶点 3 经度'), '0');
+  await user.clear(screen.getByLabelText('顶点 3 纬度'));
+  await user.type(screen.getByLabelText('顶点 3 纬度'), '0.002');
 }
 
 describe('ProductEditor', () => {
@@ -56,6 +71,20 @@ describe('ProductEditor', () => {
     expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.getAllByText('此项为必填')).toHaveLength(6);
     expect(screen.getByText('请至少添加一个风险区域')).toBeInTheDocument();
+  });
+
+  it('adds a vertex at the map center by default', async () => {
+    localStorage.removeItem(NEW_STORAGE_KEY);
+    const { ProductEditor } = await importFreshEditor();
+
+    render(<ProductEditor open onClose={() => {}} onSubmit={() => {}} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '新增区域' }));
+    await user.click(screen.getByRole('button', { name: '添加顶点' }));
+
+    expect(screen.getByLabelText('顶点 1 经度')).toHaveValue(116.391);
+    expect(screen.getByLabelText('顶点 1 纬度')).toHaveValue(39.9075);
   });
 
   it('validates time ordering rules', async () => {
@@ -110,8 +139,15 @@ describe('ProductEditor', () => {
     await user.click(screen.getByRole('button', { name: '添加顶点' }));
     await user.click(screen.getByRole('button', { name: '添加顶点' }));
 
+    await user.clear(screen.getByLabelText('顶点 1 经度'));
+    await user.type(screen.getByLabelText('顶点 1 经度'), '0');
+    await user.clear(screen.getByLabelText('顶点 1 纬度'));
+    await user.type(screen.getByLabelText('顶点 1 纬度'), '0');
+
     await user.clear(screen.getByLabelText('顶点 2 经度'));
     await user.type(screen.getByLabelText('顶点 2 经度'), '1');
+    await user.clear(screen.getByLabelText('顶点 2 纬度'));
+    await user.type(screen.getByLabelText('顶点 2 纬度'), '0');
     await user.clear(screen.getByLabelText('顶点 3 经度'));
     await user.type(screen.getByLabelText('顶点 3 经度'), '1');
     await user.clear(screen.getByLabelText('顶点 3 纬度'));

--- a/apps/web/src/features/products/ProductEditor.tsx
+++ b/apps/web/src/features/products/ProductEditor.tsx
@@ -728,7 +728,9 @@ export function ProductEditor({
                             type="button"
                             className="rounded-lg border border-slate-400/20 bg-slate-700/30 px-2 py-1 text-xs text-slate-200 hover:bg-slate-700/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
                             onClick={() => {
-                              const nextVertices = [...activeHazard.vertices, { lon: 0, lat: 0 }];
+                              const lastVertex = activeHazard.vertices[activeHazard.vertices.length - 1];
+                              const nextVertex = lastVertex ? { ...lastVertex } : { lon: 116.391, lat: 39.9075 };
+                              const nextVertices = [...activeHazard.vertices, nextVertex];
                               updateValues({
                                 hazards: values.hazards.map((hazard) =>
                                   hazard.id === activeHazard.id

--- a/apps/web/src/features/products/ProductEditor.tsx
+++ b/apps/web/src/features/products/ProductEditor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useModal } from '../../lib/useModal';
+import { bboxFromLonLat, polygonAreaKm2, polygonHasSelfIntersections } from '../../lib/geo';
 import { createEmptyProductDraft, getProductDraftStorageKey, useProductDraftStore } from '../../state/productDraft';
 
 import {
@@ -13,6 +14,7 @@ import {
   type ProductEditorSubmitValues,
   type ProductEditorValues,
 } from './productEditorValidation';
+import { HazardPolygonMap } from './HazardPolygonMap';
 
 export type { ProductEditorValues };
 
@@ -26,6 +28,10 @@ function fieldClasses(hasError: boolean): string {
     'bg-slate-950/30 placeholder:text-slate-500',
     hasError ? 'border-rose-400/40 focus:border-rose-400/60 focus:ring-2 focus:ring-rose-400/30' : 'border-slate-400/20 focus:border-blue-400/50 focus:ring-2 focus:ring-blue-400/30',
   ].join(' ');
+}
+
+function createHazardId(): string {
+  return `hazard-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
 }
 
 type Props = {
@@ -76,6 +82,11 @@ export function ProductEditor({
     if (isEditing) return baseValues;
     return useProductDraftStore.getState(storageKey).draft ?? baseValues;
   });
+  const [activeHazardId, setActiveHazardId] = useState<string | null>(() => {
+    const initialDraft = isEditing ? baseValues : useProductDraftStore.getState(storageKey).draft ?? baseValues;
+    return initialDraft.hazards[0]?.id ?? null;
+  });
+  const [isDrawingHazard, setIsDrawingHazard] = useState(false);
   const [errors, setErrors] = useState<ProductEditorErrors>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -95,6 +106,7 @@ export function ProductEditor({
       valid_to: `product-editor-valid-to-${baseId}`,
       type: `product-editor-type-${baseId}`,
       severity: `product-editor-severity-${baseId}`,
+      hazards: `product-editor-hazards-${baseId}`,
     };
   }, [baseId]);
 
@@ -110,6 +122,8 @@ export function ProductEditor({
     const stored = useProductDraftStore.getState(storageKey).draft;
     const nextValues = !isEditing && stored ? stored : baseValues;
     setValues(nextValues);
+    setActiveHazardId(nextValues.hazards[0]?.id ?? null);
+    setIsDrawingHazard(false);
     setErrors({});
     setSubmitError(null);
     setIsSubmitting(false);
@@ -131,14 +145,42 @@ export function ProductEditor({
     return date.toLocaleString();
   }, [savedDraftUpdatedAt]);
 
-  function updateField(field: keyof ProductEditorValues, value: string) {
+  type TextField = 'title' | 'text' | 'issued_at' | 'valid_from' | 'valid_to' | 'type' | 'severity';
+
+  function updateValues(patch: Partial<ProductEditorValues>) {
     setValues((current) => {
-      const next = { ...current, [field]: value };
+      const next = { ...current, ...patch };
       if (!validatedOnce) return next;
       setErrors(validateProductEditor(next));
       return next;
     });
   }
+
+  function updateField(field: TextField, value: string) {
+    updateValues({ [field]: value } as Pick<ProductEditorValues, TextField>);
+  }
+
+  function updateHazards(
+    update: (hazards: ProductEditorValues['hazards']) => ProductEditorValues['hazards'],
+  ) {
+    setValues((current) => {
+      const hazards = update(current.hazards);
+      const next = { ...current, hazards };
+      if (!validatedOnce) return next;
+      setErrors(validateProductEditor(next));
+      return next;
+    });
+  }
+
+  useEffect(() => {
+    if (values.hazards.length === 0) {
+      if (activeHazardId !== null) setActiveHazardId(null);
+      return;
+    }
+    if (!activeHazardId || !values.hazards.some((hazard) => hazard.id === activeHazardId)) {
+      setActiveHazardId(values.hazards[0]!.id);
+    }
+  }, [activeHazardId, values.hazards]);
 
   async function handleSubmit() {
     setValidatedOnce(true);
@@ -170,11 +212,36 @@ export function ProductEditor({
     const draft = useProductDraftStore.getState(storageKey).draft;
     if (!draft) return;
     setValues(draft);
+    setActiveHazardId(draft.hazards[0]?.id ?? null);
+    setIsDrawingHazard(false);
     setErrors({});
     setSubmitError(null);
     setValidatedOnce(false);
     setRestoredDraft(true);
   }
+
+  const hazardsSummary = useMemo(() => {
+    return values.hazards.map((hazard) => {
+      const bbox = bboxFromLonLat(hazard.vertices);
+      const areaKm2 = polygonAreaKm2(hazard.vertices);
+      const selfIntersecting =
+        hazard.vertices.length >= 4 ? polygonHasSelfIntersections(hazard.vertices) : false;
+
+      return {
+        id: hazard.id,
+        vertices: hazard.vertices,
+        bbox,
+        areaKm2,
+        selfIntersecting,
+        isComplete: hazard.vertices.length >= 3,
+      };
+    });
+  }, [values.hazards]);
+
+  const activeHazard = useMemo(() => {
+    if (!activeHazardId) return null;
+    return hazardsSummary.find((hazard) => hazard.id === activeHazardId) ?? null;
+  }, [activeHazardId, hazardsSummary]);
 
   if (!open) return null;
 
@@ -225,6 +292,8 @@ export function ProductEditor({
               onClick={() => {
                 useProductDraftStore.getState(storageKey).clearDraft();
                 setValues(baseValues);
+                setActiveHazardId(baseValues.hazards[0]?.id ?? null);
+                setIsDrawingHazard(false);
                 setErrors({});
                 setSubmitError(null);
                 setValidatedOnce(false);
@@ -421,6 +490,349 @@ export function ProductEditor({
                   <li>有效开始时间需早于有效结束时间</li>
                   <li>发布时间需早于或等于有效开始时间</li>
                 </ul>
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-slate-400/10 bg-slate-900/10 p-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium text-slate-200">
+                    风险区域 <span className="text-rose-300">*</span>
+                  </div>
+                  <div className="mt-1 text-xs text-slate-400">
+                    点击地图添加顶点，拖拽顶点编辑位置；右键或按钮删除顶点；双击或按钮完成绘制。
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className="rounded-lg border border-slate-400/20 bg-slate-700/30 px-2 py-1 text-xs text-slate-200 hover:bg-slate-700/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                    onClick={() => {
+                      const id = createHazardId();
+                      updateValues({
+                        hazards: [...values.hazards, { id, vertices: [] }],
+                      });
+                      setActiveHazardId(id);
+                      setIsDrawingHazard(true);
+                    }}
+                  >
+                    新增区域
+                  </button>
+                  {activeHazard ? (
+                    <button
+                      type="button"
+                      className="rounded-lg border border-rose-400/20 bg-rose-500/10 px-2 py-1 text-xs text-rose-200 hover:bg-rose-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-rose-400"
+                      onClick={() => {
+                        const next = values.hazards.filter((hazard) => hazard.id !== activeHazard.id);
+                        updateValues({ hazards: next });
+                        setActiveHazardId(next[0]?.id ?? null);
+                        setIsDrawingHazard(false);
+                      }}
+                      aria-label="删除当前风险区域"
+                    >
+                      删除当前
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+
+              {errors.hazards ? (
+                <div id={`${fieldIds.hazards}-error`} className="mt-2 text-xs text-rose-200" role="alert">
+                  {errors.hazards}
+                </div>
+              ) : null}
+
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <div className="grid gap-3">
+                  <div className="grid gap-2">
+                    {hazardsSummary.length === 0 ? (
+                      <div className="text-sm text-slate-400">尚未添加风险区域。</div>
+                    ) : (
+                      <div className="grid gap-2">
+                        {hazardsSummary.map((hazard, index) => {
+                          const selected = hazard.id === activeHazardId;
+                          const status = hazard.selfIntersecting
+                            ? '自交'
+                            : hazard.vertices.length < 3
+                              ? `点数不足(${hazard.vertices.length}/3)`
+                              : '已完成';
+
+                          return (
+                            <button
+                              key={hazard.id}
+                              type="button"
+                              className={[
+                                'flex w-full items-center justify-between gap-3 rounded-lg border px-3 py-2 text-left text-xs transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400',
+                                selected
+                                  ? 'border-blue-400/60 bg-blue-500/10'
+                                  : 'border-slate-400/10 bg-slate-950/10 hover:bg-slate-950/20',
+                              ].join(' ')}
+                              onClick={() => {
+                                setActiveHazardId(hazard.id);
+                                setIsDrawingHazard(false);
+                              }}
+                              aria-selected={selected}
+                            >
+                              <div className="min-w-0">
+                                <div className="truncate font-medium text-slate-100">区域 {index + 1}</div>
+                                <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-slate-400">
+                                  <span>顶点: {hazard.vertices.length}</span>
+                                  <span>
+                                    面积:{' '}
+                                    {hazard.areaKm2 == null ? '—' : `${hazard.areaKm2.toFixed(2)} km²`}
+                                  </span>
+                                  <span
+                                    className={
+                                      hazard.selfIntersecting ? 'text-rose-200' : 'text-slate-400'
+                                    }
+                                  >
+                                    状态: {status}
+                                  </span>
+                                </div>
+                              </div>
+                              {selected ? (
+                                <span className="shrink-0 rounded-md border border-blue-400/30 bg-blue-500/10 px-2 py-0.5 text-[11px] text-blue-100">
+                                  当前
+                                </span>
+                              ) : null}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="rounded-lg border border-slate-400/20 bg-slate-700/30 px-2 py-1 text-xs text-slate-200 hover:bg-slate-700/50 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                      disabled={!activeHazard}
+                      onClick={() => setIsDrawingHazard(true)}
+                    >
+                      {isDrawingHazard ? '绘制中…' : '开始/继续绘制'}
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-lg border border-blue-400/30 bg-blue-500/20 px-2 py-1 text-xs text-blue-100 hover:bg-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                      disabled={!isDrawingHazard}
+                      onClick={() => setIsDrawingHazard(false)}
+                    >
+                      完成绘制
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-lg border border-slate-400/20 bg-slate-700/30 px-2 py-1 text-xs text-slate-200 hover:bg-slate-700/50 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                      disabled={!activeHazard || activeHazard.vertices.length === 0}
+                      onClick={() => {
+                        if (!activeHazard) return;
+                        const nextVertices = activeHazard.vertices.slice(0, -1);
+                        updateValues({
+                          hazards: values.hazards.map((hazard) =>
+                            hazard.id === activeHazard.id ? { ...hazard, vertices: nextVertices } : hazard,
+                          ),
+                        });
+                      }}
+                    >
+                      删除最后顶点
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-lg border border-slate-400/20 bg-slate-700/30 px-2 py-1 text-xs text-slate-200 hover:bg-slate-700/50 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                      disabled={!activeHazard || activeHazard.vertices.length === 0}
+                      onClick={() => {
+                        if (!activeHazard) return;
+                        updateValues({
+                          hazards: values.hazards.map((hazard) =>
+                            hazard.id === activeHazard.id ? { ...hazard, vertices: [] } : hazard,
+                          ),
+                        });
+                      }}
+                    >
+                      清空顶点
+                    </button>
+                  </div>
+
+                  <HazardPolygonMap
+                    hazards={values.hazards}
+                    activeHazardId={activeHazardId}
+                    drawing={isDrawingHazard}
+                    onSetActiveHazardId={(id) => {
+                      setActiveHazardId(id);
+                      setIsDrawingHazard(false);
+                    }}
+                    onFinishDrawing={() => setIsDrawingHazard(false)}
+                    onDeleteVertex={(hazardId, vertexIndex) => {
+                      updateHazards((hazards) =>
+                        hazards.map((hazard) => {
+                          if (hazard.id !== hazardId) return hazard;
+                          return {
+                            ...hazard,
+                            vertices: hazard.vertices.filter((_, index) => index !== vertexIndex),
+                          };
+                        }),
+                      );
+                    }}
+                    onChangeVertices={(hazardId, vertices) => {
+                      updateHazards((hazards) =>
+                        hazards.map((hazard) =>
+                          hazard.id === hazardId ? { ...hazard, vertices } : hazard,
+                        ),
+                      );
+                    }}
+                  />
+                </div>
+
+                <div className="grid gap-3">
+                  {!activeHazard ? (
+                    <div className="rounded-lg border border-slate-400/10 bg-slate-950/10 p-3 text-sm text-slate-400">
+                      请选择或新增一个风险区域以编辑顶点。
+                    </div>
+                  ) : (
+                    <div className="grid gap-3">
+                      <div className="rounded-lg border border-slate-400/10 bg-slate-950/10 p-3 text-xs text-slate-300">
+                        <div className="grid gap-1">
+                          <div>
+                            顶点数: <span className="font-medium">{activeHazard.vertices.length}</span>
+                          </div>
+                          <div>
+                            面积:{' '}
+                            <span className="font-medium">
+                              {activeHazard.areaKm2 == null ? '—' : `${activeHazard.areaKm2.toFixed(2)} km²`}
+                            </span>
+                          </div>
+                          <div>
+                            bbox:{' '}
+                            <span className="font-medium">
+                              {activeHazard.bbox
+                                ? `lon[${activeHazard.bbox.min_x.toFixed(4)}, ${activeHazard.bbox.max_x.toFixed(4)}], lat[${activeHazard.bbox.min_y.toFixed(4)}, ${activeHazard.bbox.max_y.toFixed(4)}]`
+                                : '—'}
+                            </span>
+                          </div>
+                        </div>
+                        {activeHazard.selfIntersecting ? (
+                          <div className="mt-2 rounded-md border border-rose-400/20 bg-rose-500/10 p-2 text-rose-200">
+                            检测到多边形自交，请调整顶点。
+                          </div>
+                        ) : null}
+                        {activeHazard.vertices.length > 0 && activeHazard.vertices.length < 3 ? (
+                          <div className="mt-2 rounded-md border border-amber-400/20 bg-amber-500/10 p-2 text-amber-100">
+                            多边形至少需要 3 个顶点。
+                          </div>
+                        ) : null}
+                      </div>
+
+                      <div className="rounded-lg border border-slate-400/10 bg-slate-950/10 p-3">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="text-sm font-medium text-slate-200">顶点列表</div>
+                          <button
+                            type="button"
+                            className="rounded-lg border border-slate-400/20 bg-slate-700/30 px-2 py-1 text-xs text-slate-200 hover:bg-slate-700/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-400"
+                            onClick={() => {
+                              const nextVertices = [...activeHazard.vertices, { lon: 0, lat: 0 }];
+                              updateValues({
+                                hazards: values.hazards.map((hazard) =>
+                                  hazard.id === activeHazard.id
+                                    ? { ...hazard, vertices: nextVertices }
+                                    : hazard,
+                                ),
+                              });
+                            }}
+                          >
+                            添加顶点
+                          </button>
+                        </div>
+
+                        {activeHazard.vertices.length === 0 ? (
+                          <div className="mt-2 text-sm text-slate-400">暂无顶点，可点击地图或按钮添加。</div>
+                        ) : (
+                          <div className="mt-2 grid gap-2">
+                            {activeHazard.vertices.map((vertex, index) => {
+                              const lonId = `${fieldIds.hazards}-lon-${activeHazard.id}-${index}`;
+                              const latId = `${fieldIds.hazards}-lat-${activeHazard.id}-${index}`;
+                              return (
+                                <div
+                                  key={`${activeHazard.id}-${index}`}
+                                  className="grid grid-cols-[1fr_1fr_auto] items-center gap-2"
+                                >
+                                  <div>
+                                    <label htmlFor={lonId} className="sr-only">
+                                      顶点 {index + 1} 经度
+                                    </label>
+                                    <input
+                                      id={lonId}
+                                      type="number"
+                                      step="0.0001"
+                                      className={fieldClasses(false)}
+                                      value={String(vertex.lon)}
+                                      onChange={(event) => {
+                                        const value = Number(event.target.value);
+                                        if (!Number.isFinite(value)) return;
+                                        const nextVertices = activeHazard.vertices.map((current, i) =>
+                                          i === index ? { ...current, lon: value } : current,
+                                        );
+                                        updateValues({
+                                          hazards: values.hazards.map((hazard) =>
+                                            hazard.id === activeHazard.id
+                                              ? { ...hazard, vertices: nextVertices }
+                                              : hazard,
+                                          ),
+                                        });
+                                      }}
+                                    />
+                                  </div>
+                                  <div>
+                                    <label htmlFor={latId} className="sr-only">
+                                      顶点 {index + 1} 纬度
+                                    </label>
+                                    <input
+                                      id={latId}
+                                      type="number"
+                                      step="0.0001"
+                                      className={fieldClasses(false)}
+                                      value={String(vertex.lat)}
+                                      onChange={(event) => {
+                                        const value = Number(event.target.value);
+                                        if (!Number.isFinite(value)) return;
+                                        const nextVertices = activeHazard.vertices.map((current, i) =>
+                                          i === index ? { ...current, lat: value } : current,
+                                        );
+                                        updateValues({
+                                          hazards: values.hazards.map((hazard) =>
+                                            hazard.id === activeHazard.id
+                                              ? { ...hazard, vertices: nextVertices }
+                                              : hazard,
+                                          ),
+                                        });
+                                      }}
+                                    />
+                                  </div>
+                                  <button
+                                    type="button"
+                                    className="rounded-lg border border-rose-400/20 bg-rose-500/10 px-2 py-1 text-xs text-rose-200 hover:bg-rose-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-rose-400"
+                                    onClick={() => {
+                                      updateValues({
+                                        hazards: values.hazards.map((hazard) => {
+                                          if (hazard.id !== activeHazard.id) return hazard;
+                                          return {
+                                            ...hazard,
+                                            vertices: hazard.vertices.filter((_, i) => i !== index),
+                                          };
+                                        }),
+                                      });
+                                    }}
+                                    aria-label={`删除顶点 ${index + 1}`}
+                                  >
+                                    删除
+                                  </button>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
 

--- a/apps/web/src/features/products/productEditorValidation.test.ts
+++ b/apps/web/src/features/products/productEditorValidation.test.ts
@@ -27,9 +27,19 @@ describe('productEditorValidation', () => {
       issued_at: '2026-01-01T00:00',
       valid_from: '2026-01-01T00:00',
       valid_to: '2026-01-02T00:00',
+      hazards: [
+        {
+          id: 'h1',
+          vertices: [
+            { lon: 0, lat: 0 },
+            { lon: 1, lat: 0 },
+            { lon: 1, lat: 1 },
+          ],
+        },
+      ],
     });
 
-    expect(normalized).toEqual({
+    expect(normalized).toMatchObject({
       title: 'Title',
       type: 'snow',
       severity: '',
@@ -37,7 +47,26 @@ describe('productEditorValidation', () => {
       issued_at: '2026-01-01T00:00:00.000Z',
       valid_from: '2026-01-01T00:00:00.000Z',
       valid_to: '2026-01-02T00:00:00.000Z',
+      hazards: [
+        {
+          id: 'h1',
+          bbox: { min_x: 0, min_y: 0, max_x: 1, max_y: 1 },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 0],
+              ],
+            ],
+          },
+        },
+      ],
     });
+    expect(normalized.hazards[0]!.area_km2).toBeTypeOf('number');
+    expect(normalized.hazards[0]!.area_km2).toBeGreaterThan(0);
   });
 
   it('validates severity values', () => {
@@ -49,9 +78,69 @@ describe('productEditorValidation', () => {
       issued_at: '2026-01-01T00:00',
       valid_from: '2026-01-01T00:00',
       valid_to: '2026-01-02T00:00',
+      hazards: [
+        {
+          id: 'h1',
+          vertices: [
+            { lon: 0, lat: 0 },
+            { lon: 1, lat: 0 },
+            { lon: 1, lat: 1 },
+          ],
+        },
+      ],
     });
 
     expect(errors.severity).toBe('严重程度必须为 low / medium / high 或留空');
   });
-});
 
+  it('validates hazard polygons', () => {
+    expect(
+      validateProductEditor({
+        title: 'Title',
+        type: 'snow',
+        severity: '',
+        text: 'Body',
+        issued_at: '2026-01-01T00:00',
+        valid_from: '2026-01-01T00:00',
+        valid_to: '2026-01-02T00:00',
+        hazards: [],
+      }).hazards,
+    ).toBe('请至少添加一个风险区域');
+
+    expect(
+      validateProductEditor({
+        title: 'Title',
+        type: 'snow',
+        severity: '',
+        text: 'Body',
+        issued_at: '2026-01-01T00:00',
+        valid_from: '2026-01-01T00:00',
+        valid_to: '2026-01-02T00:00',
+        hazards: [{ id: 'h1', vertices: [{ lon: 0, lat: 0 }] }],
+      }).hazards,
+    ).toContain('至少需要 3 个顶点');
+
+    expect(
+      validateProductEditor({
+        title: 'Title',
+        type: 'snow',
+        severity: '',
+        text: 'Body',
+        issued_at: '2026-01-01T00:00',
+        valid_from: '2026-01-01T00:00',
+        valid_to: '2026-01-02T00:00',
+        hazards: [
+          {
+            id: 'h1',
+            vertices: [
+              { lon: 0, lat: 0 },
+              { lon: 2, lat: 2 },
+              { lon: 0, lat: 2 },
+              { lon: 2, lat: 0 },
+            ],
+          },
+        ],
+      }).hazards,
+    ).toContain('多边形存在自交');
+  });
+});

--- a/apps/web/src/features/products/productEditorValidation.ts
+++ b/apps/web/src/features/products/productEditorValidation.ts
@@ -1,4 +1,11 @@
-import type { ProductDraft } from '../../state/productDraft';
+import {
+  bboxFromLonLat,
+  geoJsonPolygonFromLonLat,
+  polygonAreaKm2,
+  polygonHasSelfIntersections,
+  type BBox,
+} from '../../lib/geo';
+import type { ProductDraft, ProductHazardDraft } from '../../state/productDraft';
 
 /**
  * Form values for the product editor.
@@ -8,15 +15,23 @@ import type { ProductDraft } from '../../state/productDraft';
  */
 export type ProductEditorValues = ProductDraft;
 
+export type ProductEditorHazardSubmit = {
+  id: string;
+  geometry: { type: 'Polygon'; coordinates: number[][][] };
+  bbox: BBox;
+  area_km2: number;
+};
+
 /**
  * Payload values after normalization.
  *
  * Date fields are ISO 8601 strings in UTC (e.g. `2026-01-01T00:00:00.000Z`).
  */
-export type ProductEditorSubmitValues = Omit<ProductDraft, 'issued_at' | 'valid_from' | 'valid_to'> & {
+export type ProductEditorSubmitValues = Omit<ProductDraft, 'issued_at' | 'valid_from' | 'valid_to' | 'hazards'> & {
   issued_at: string;
   valid_from: string;
   valid_to: string;
+  hazards: ProductEditorHazardSubmit[];
 };
 
 export type ProductEditorErrors = Partial<Record<keyof ProductEditorValues, string>> & {
@@ -137,6 +152,21 @@ export function normalizeProductEditorValues(values: ProductEditorValues): Produ
   const validFromIso = datetimeLocalToIso(values.valid_from);
   const validToIso = datetimeLocalToIso(values.valid_to);
 
+  const normalizedHazards: ProductEditorHazardSubmit[] = values.hazards
+    .map((hazard) => {
+      const geometry = geoJsonPolygonFromLonLat(hazard.vertices);
+      const bbox = bboxFromLonLat(hazard.vertices);
+      const area_km2 = polygonAreaKm2(hazard.vertices);
+      if (!geometry || !bbox || area_km2 == null) return null;
+      return {
+        id: hazard.id,
+        geometry,
+        bbox,
+        area_km2,
+      };
+    })
+    .filter((hazard): hazard is ProductEditorHazardSubmit => hazard != null);
+
   return {
     title: normalizeText(values.title),
     text: normalizeText(values.text),
@@ -145,13 +175,20 @@ export function normalizeProductEditorValues(values: ProductEditorValues): Produ
     valid_to: validToIso ?? normalizeText(values.valid_to),
     type: normalizeText(values.type),
     severity: normalizeText(values.severity),
+    hazards: normalizedHazards,
   };
+}
+
+function hazardStatus(hazard: ProductHazardDraft): string | null {
+  if (hazard.vertices.length < 3) return '至少需要 3 个顶点';
+  if (polygonHasSelfIntersections(hazard.vertices)) return '多边形存在自交';
+  return null;
 }
 
 export function validateProductEditor(values: ProductEditorValues): ProductEditorErrors {
   const errors: ProductEditorErrors = {};
 
-  const required: Array<keyof ProductEditorValues> = [
+  const required: Array<'title' | 'text' | 'issued_at' | 'valid_from' | 'valid_to' | 'type'> = [
     'title',
     'text',
     'issued_at',
@@ -164,6 +201,18 @@ export function validateProductEditor(values: ProductEditorValues): ProductEdito
     if (!normalizeText(values[field])) {
       errors[field] = '此项为必填';
     }
+  }
+
+  if (values.hazards.length === 0) {
+    errors.hazards = '请至少添加一个风险区域';
+  } else {
+    const hazardMessages: string[] = [];
+    values.hazards.forEach((hazard, index) => {
+      const status = hazardStatus(hazard);
+      if (!status) return;
+      hazardMessages.push(`风险区域 ${index + 1}: ${status}`);
+    });
+    if (hazardMessages.length > 0) errors.hazards = hazardMessages.join('；');
   }
 
   const issuedAtMs = toEpochMs(values.issued_at);
@@ -186,7 +235,7 @@ export function validateProductEditor(values: ProductEditorValues): ProductEdito
   }
 
   if (issuedAtMs != null && validFromMs != null && issuedAtMs > validFromMs) {
-      errors.issued_at = '发布时间需早于或等于有效开始时间';
+    errors.issued_at = '发布时间需早于或等于有效开始时间';
   }
 
   const severity = normalizeText(values.severity);

--- a/apps/web/src/features/viewer/geoJsonPolygons.ts
+++ b/apps/web/src/features/viewer/geoJsonPolygons.ts
@@ -1,4 +1,6 @@
-export type LonLat = { lon: number; lat: number };
+import type { LonLat } from '../../lib/geo';
+
+export type { LonLat };
 export type PolygonLonLat = { outer: LonLat[]; holes: LonLat[][] };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -70,4 +72,3 @@ export function extractGeoJsonPolygons(value: unknown): PolygonLonLat[] {
 
   return [];
 }
-

--- a/apps/web/src/lib/geo.test.ts
+++ b/apps/web/src/lib/geo.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  bboxFromLonLat,
+  geoJsonPolygonFromLonLat,
+  geoJsonRingFromLonLat,
+  polygonAreaKm2,
+  polygonHasSelfIntersections,
+} from './geo';
+
+describe('geo', () => {
+  it('bboxFromLonLat returns null for empty input', () => {
+    expect(bboxFromLonLat([])).toBeNull();
+  });
+
+  it('bboxFromLonLat computes min/max bounds', () => {
+    expect(
+      bboxFromLonLat([
+        { lon: 10, lat: 5 },
+        { lon: -1, lat: 8 },
+        { lon: 3, lat: -2 },
+      ]),
+    ).toEqual({ min_x: -1, min_y: -2, max_x: 10, max_y: 8 });
+  });
+
+  it('geoJsonRingFromLonLat closes the ring', () => {
+    expect(
+      geoJsonRingFromLonLat([
+        { lon: 0, lat: 0 },
+        { lon: 1, lat: 0 },
+        { lon: 1, lat: 1 },
+      ]),
+    ).toEqual([
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [0, 0],
+    ]);
+  });
+
+  it('geoJsonRingFromLonLat preserves already-closed rings', () => {
+    expect(
+      geoJsonRingFromLonLat([
+        { lon: 0, lat: 0 },
+        { lon: 1, lat: 0 },
+        { lon: 1, lat: 1 },
+        { lon: 0, lat: 0 },
+      ]),
+    ).toEqual([
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [0, 0],
+    ]);
+  });
+
+  it('geoJsonPolygonFromLonLat returns null when fewer than 3 vertices', () => {
+    expect(geoJsonPolygonFromLonLat([])).toBeNull();
+    expect(geoJsonPolygonFromLonLat([{ lon: 0, lat: 0 }])).toBeNull();
+    expect(
+      geoJsonPolygonFromLonLat([
+        { lon: 0, lat: 0 },
+        { lon: 1, lat: 0 },
+      ]),
+    ).toBeNull();
+  });
+
+  it('geoJsonPolygonFromLonLat creates a Polygon geometry', () => {
+    expect(
+      geoJsonPolygonFromLonLat([
+        { lon: 0, lat: 0 },
+        { lon: 1, lat: 0 },
+        { lon: 1, lat: 1 },
+      ]),
+    ).toEqual({
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 0],
+        ],
+      ],
+    });
+  });
+
+  it('polygonAreaKm2 returns null when fewer than 3 vertices', () => {
+    expect(polygonAreaKm2([])).toBeNull();
+    expect(polygonAreaKm2([{ lon: 0, lat: 0 }])).toBeNull();
+    expect(
+      polygonAreaKm2([
+        { lon: 0, lat: 0 },
+        { lon: 1, lat: 0 },
+      ]),
+    ).toBeNull();
+  });
+
+  it('polygonAreaKm2 computes a reasonable area for a 1x1 degree square near the equator', () => {
+    const area = polygonAreaKm2([
+      { lon: 0, lat: 0 },
+      { lon: 1, lat: 0 },
+      { lon: 1, lat: 1 },
+      { lon: 0, lat: 1 },
+    ]);
+
+    expect(area).not.toBeNull();
+    // Roughly 12,300 km^2; allow generous bounds to avoid brittle tests.
+    expect(area!).toBeGreaterThan(11_000);
+    expect(area!).toBeLessThan(14_000);
+  });
+
+  it('polygonHasSelfIntersections detects self-crossing polygons', () => {
+    expect(
+      polygonHasSelfIntersections([
+        { lon: 0, lat: 0 },
+        { lon: 2, lat: 0 },
+        { lon: 2, lat: 2 },
+        { lon: 0, lat: 2 },
+      ]),
+    ).toBe(false);
+
+    // Bow-tie polygon (self-intersecting).
+    expect(
+      polygonHasSelfIntersections([
+        { lon: 0, lat: 0 },
+        { lon: 2, lat: 2 },
+        { lon: 0, lat: 2 },
+        { lon: 2, lat: 0 },
+      ]),
+    ).toBe(true);
+  });
+});
+

--- a/apps/web/src/lib/geo.ts
+++ b/apps/web/src/lib/geo.ts
@@ -1,0 +1,135 @@
+export type LonLat = { lon: number; lat: number };
+
+export type BBox = {
+  min_x: number;
+  min_y: number;
+  max_x: number;
+  max_y: number;
+};
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+export function bboxFromLonLat(vertices: LonLat[]): BBox | null {
+  if (vertices.length === 0) return null;
+
+  let minLon = vertices[0]!.lon;
+  let maxLon = vertices[0]!.lon;
+  let minLat = vertices[0]!.lat;
+  let maxLat = vertices[0]!.lat;
+
+  for (const vertex of vertices.slice(1)) {
+    minLon = Math.min(minLon, vertex.lon);
+    maxLon = Math.max(maxLon, vertex.lon);
+    minLat = Math.min(minLat, vertex.lat);
+    maxLat = Math.max(maxLat, vertex.lat);
+  }
+
+  return { min_x: minLon, min_y: minLat, max_x: maxLon, max_y: maxLat };
+}
+
+export function geoJsonRingFromLonLat(vertices: LonLat[]): number[][] {
+  if (vertices.length === 0) return [];
+
+  const ring = vertices.map((vertex) => [vertex.lon, vertex.lat]);
+  const first = vertices[0]!;
+  const last = vertices[vertices.length - 1]!;
+  if (!Object.is(first.lon, last.lon) || !Object.is(first.lat, last.lat)) {
+    ring.push([first.lon, first.lat]);
+  }
+  return ring;
+}
+
+export function geoJsonPolygonFromLonLat(
+  vertices: LonLat[],
+): { type: 'Polygon'; coordinates: number[][][] } | null {
+  if (vertices.length < 3) return null;
+  return { type: 'Polygon', coordinates: [geoJsonRingFromLonLat(vertices)] };
+}
+
+/**
+ * Returns the approximate spherical polygon area in square kilometers.
+ * Uses the same algorithm as mapbox/geojson-area (spherical excess approximation).
+ */
+export function polygonAreaKm2(vertices: LonLat[]): number | null {
+  if (vertices.length < 3) return null;
+
+  // WGS84 semi-major axis; aligns well with Cesium's default ellipsoid.
+  const earthRadiusMeters = 6_378_137;
+
+  let sum = 0;
+  for (let index = 0; index < vertices.length; index += 1) {
+    const current = vertices[index]!;
+    const next = vertices[(index + 1) % vertices.length]!;
+
+    const lon1 = toRadians(current.lon);
+    const lon2 = toRadians(next.lon);
+    const lat1 = toRadians(current.lat);
+    const lat2 = toRadians(next.lat);
+
+    sum += (lon2 - lon1) * (2 + Math.sin(lat1) + Math.sin(lat2));
+  }
+
+  const areaMeters2 = (sum * earthRadiusMeters * earthRadiusMeters) / 2;
+  return Math.abs(areaMeters2) / 1_000_000;
+}
+
+type Point2 = { x: number; y: number };
+
+function orientation(a: Point2, b: Point2, c: Point2): number {
+  return (b.y - a.y) * (c.x - b.x) - (b.x - a.x) * (c.y - b.y);
+}
+
+function onSegment(a: Point2, b: Point2, c: Point2): boolean {
+  return (
+    Math.min(a.x, c.x) <= b.x &&
+    b.x <= Math.max(a.x, c.x) &&
+    Math.min(a.y, c.y) <= b.y &&
+    b.y <= Math.max(a.y, c.y)
+  );
+}
+
+function segmentsIntersect(p1: Point2, q1: Point2, p2: Point2, q2: Point2): boolean {
+  const o1 = orientation(p1, q1, p2);
+  const o2 = orientation(p1, q1, q2);
+  const o3 = orientation(p2, q2, p1);
+  const o4 = orientation(p2, q2, q1);
+
+  if (o1 === 0 && onSegment(p1, p2, q1)) return true;
+  if (o2 === 0 && onSegment(p1, q2, q1)) return true;
+  if (o3 === 0 && onSegment(p2, p1, q2)) return true;
+  if (o4 === 0 && onSegment(p2, q1, q2)) return true;
+
+  return (o1 > 0) !== (o2 > 0) && (o3 > 0) !== (o4 > 0);
+}
+
+function isAdjacentEdge(a: number, b: number, vertexCount: number): boolean {
+  if (a === b) return true;
+  if ((a + 1) % vertexCount === b) return true;
+  if ((b + 1) % vertexCount === a) return true;
+  return false;
+}
+
+export function polygonHasSelfIntersections(vertices: LonLat[]): boolean {
+  if (vertices.length < 4) return false;
+
+  const points = vertices.map((vertex) => ({ x: vertex.lon, y: vertex.lat }));
+
+  for (let edgeA = 0; edgeA < points.length; edgeA += 1) {
+    const a1 = points[edgeA]!;
+    const a2 = points[(edgeA + 1) % points.length]!;
+
+    for (let edgeB = edgeA + 1; edgeB < points.length; edgeB += 1) {
+      if (isAdjacentEdge(edgeA, edgeB, points.length)) continue;
+
+      const b1 = points[edgeB]!;
+      const b2 = points[(edgeB + 1) % points.length]!;
+
+      if (segmentsIntersect(a1, a2, b1, b2)) return true;
+    }
+  }
+
+  return false;
+}
+

--- a/apps/web/src/state/productDraft.test.ts
+++ b/apps/web/src/state/productDraft.test.ts
@@ -52,6 +52,7 @@ describe('productDraft store', () => {
         valid_to: '2026-01-01T02:00',
         type: 'snow',
         severity: 'low',
+        hazards: [],
       },
       updatedAt: 123,
     });
@@ -65,6 +66,7 @@ describe('productDraft store', () => {
       valid_to: '2026-01-01T02:00',
       type: 'snow',
       severity: 'low',
+      hazards: [],
     });
     expect(useProductDraftStore.getState(NEW_STORAGE_KEY).updatedAt).toBe(123);
   });
@@ -79,6 +81,7 @@ describe('productDraft store', () => {
         valid_to: '2026-01-01T02:00',
         type: 'snow',
         severity: '',
+        hazards: [],
       },
       updatedAt: null,
     });
@@ -117,6 +120,7 @@ describe('productDraft store', () => {
       valid_to: '2026-01-01T02:00',
       type: 'snow',
       severity: '',
+      hazards: [],
     });
 
     useProductDraftStore.setState(NEW_STORAGE_KEY, { draft: null });
@@ -136,6 +140,7 @@ describe('productDraft store', () => {
         valid_to: '2026-01-01T02:00',
         type: 'snow',
         severity: '',
+        hazards: [],
       },
     });
 
@@ -154,6 +159,7 @@ describe('productDraft store', () => {
       valid_to: '2026-01-01T02:00',
       type: 'snow',
       severity: '',
+      hazards: [],
     });
 
     useProductDraftStore.setState(NEW_STORAGE_KEY, { updatedAt: 999 });
@@ -174,6 +180,7 @@ describe('productDraft store', () => {
       valid_to: '2026-01-01T02:00',
       type: 'snow',
       severity: '',
+      hazards: [],
     });
 
     expect(useProductDraftStore.getState(NEW_STORAGE_KEY).draft?.title).toBe('T');
@@ -188,6 +195,7 @@ describe('productDraft store', () => {
         valid_to: '2026-01-01T02:00',
         type: 'snow',
         severity: '',
+        hazards: [],
       },
       updatedAt: new Date('2026-01-01T00:00:00Z').getTime(),
     });
@@ -226,6 +234,7 @@ describe('productDraft store', () => {
         valid_to: '2026-01-01T02:00',
         type: 'snow',
         severity: '',
+        hazards: [],
       });
     }).not.toThrow();
 
@@ -245,6 +254,7 @@ describe('productDraft store', () => {
       valid_to: '',
       type: '',
       severity: 'high',
+      hazards: [],
     });
 
     const persisted = JSON.parse(localStorage.getItem(NEW_STORAGE_KEY) ?? 'null') as unknown;
@@ -264,6 +274,7 @@ describe('productDraft store', () => {
       valid_to: '2026-01-01T02:00',
       type: 'snow',
       severity: '',
+      hazards: [],
     });
 
     useProductDraftStore.getState(NEW_STORAGE_KEY).clearDraft();
@@ -282,6 +293,7 @@ describe('productDraft store', () => {
       valid_to: '2026-01-01T02:00',
       type: 'snow',
       severity: '',
+      hazards: [],
     });
 
     useProductDraftStore.getState(PRODUCT_STORAGE_KEY).setDraft({
@@ -292,6 +304,7 @@ describe('productDraft store', () => {
       valid_to: '2026-01-02T02:00',
       type: 'rain',
       severity: 'high',
+      hazards: [],
     });
 
     expect(useProductDraftStore.getState(NEW_STORAGE_KEY).draft?.title).toBe('New Draft');


### PR DESCRIPTION
## Summary
实现产品编辑器多边形绘制功能

## Changes
- 创建 HazardPolygonMap 组件（Cesium 交互式绘制）
- 地图交互：点击添加顶点、拖拽编辑、右键删除、双击完成
- 支持多个 hazards（风险区域）管理
- 自动计算 bbox（经纬度范围）和面积（km²）
- 自交检测并实时提示
- 几何工具库：bbox/area/self-intersection 计算
- 扩展 productDraft store 支持 hazards 持久化
- 集成到 ProductEditor 表单
- 完整单元测试覆盖 (>= 90%)

## Validation Rules
- 至少 1 个 hazard
- 每个 hazard 至少 3 个顶点
- 禁止自交多边形

## Interactions
- 左键点击：添加顶点
- 拖拽顶点：编辑位置
- 右键顶点：删除顶点
- 双击地图：完成绘制
- 列表操作：删除顶点、删除区域

## Test Plan
- [x] 绘制交互测试
- [x] 几何计算测试（bbox/area/self-intersection）
- [x] 多 hazard 管理测试
- [x] 草稿持久化测试
- [x] 测试覆盖率 >= 90%
- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过

## Related Issues
Closes #98