### PR TITLE
[EP-13] 监测历史统计与差值分析

### DIFF
--- a/apps/api/migrations/versions/b7c1f9a0d3e4_st0058_historical_statistics_bias_metadata.py
+++ b/apps/api/migrations/versions/b7c1f9a0d3e4_st0058_historical_statistics_bias_metadata.py
@@ -91,4 +91,3 @@ def downgrade() -> None:
         "ix_historical_statistics_window_end", table_name="historical_statistics"
     )
     op.drop_table("historical_statistics")
-

--- a/apps/api/migrations/versions/b7c1f9a0d3e4_st0058_historical_statistics_bias_metadata.py
+++ b/apps/api/migrations/versions/b7c1f9a0d3e4_st0058_historical_statistics_bias_metadata.py
@@ -1,0 +1,94 @@
+"""[ST-0058] Historical statistics & bias metadata
+
+Revision ID: b7c1f9a0d3e4
+Revises: d2c4f6a8b0e1
+Create Date: 2026-01-22 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c1f9a0d3e4"
+down_revision: str | None = "d2c4f6a8b0e1"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "historical_statistics",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("variable", sa.String(length=64), nullable=False),
+        sa.Column("window_kind", sa.String(length=32), nullable=False),
+        sa.Column("window_key", sa.String(length=64), nullable=False),
+        sa.Column("version", sa.String(length=32), nullable=False),
+        sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("window_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("samples", sa.Integer(), nullable=False),
+        sa.Column("dataset_path", sa.String(length=2048), nullable=False),
+        sa.Column("metadata_path", sa.String(length=2048), nullable=False),
+        sa.Column("extra", sa.JSON(), server_default=sa.text("'{}'"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "source",
+            "variable",
+            "window_kind",
+            "window_key",
+            "version",
+            name="uq_historical_statistics_identity",
+        ),
+    )
+    op.create_index(
+        "ix_historical_statistics_window_end", "historical_statistics", ["window_end"]
+    )
+    op.create_index(
+        "ix_historical_statistics_variable", "historical_statistics", ["variable"]
+    )
+
+    op.create_table(
+        "bias_tile_sets",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("layer", sa.String(length=128), nullable=False),
+        sa.Column("time_key", sa.String(length=32), nullable=False),
+        sa.Column("level_key", sa.String(length=32), nullable=False),
+        sa.Column("min_zoom", sa.Integer(), nullable=False),
+        sa.Column("max_zoom", sa.Integer(), nullable=False),
+        sa.Column("formats", sa.JSON(), server_default=sa.text("'[]'"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "layer", "time_key", "level_key", name="uq_bias_tile_sets_identity"
+        ),
+    )
+    op.create_index("ix_bias_tile_sets_layer", "bias_tile_sets", ["layer"])
+    op.create_index("ix_bias_tile_sets_time_key", "bias_tile_sets", ["time_key"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_bias_tile_sets_time_key", table_name="bias_tile_sets")
+    op.drop_index("ix_bias_tile_sets_layer", table_name="bias_tile_sets")
+    op.drop_table("bias_tile_sets")
+
+    op.drop_index(
+        "ix_historical_statistics_variable", table_name="historical_statistics"
+    )
+    op.drop_index(
+        "ix_historical_statistics_window_end", table_name="historical_statistics"
+    )
+    op.drop_table("historical_statistics")
+

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -30,6 +30,74 @@
         "title": "BBoxResponse",
         "type": "object"
       },
+      "BiasTileSetItem": {
+        "additionalProperties": false,
+        "properties": {
+          "formats": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Formats",
+            "type": "array"
+          },
+          "layer": {
+            "title": "Layer",
+            "type": "string"
+          },
+          "level_key": {
+            "title": "Level Key",
+            "type": "string"
+          },
+          "max_zoom": {
+            "title": "Max Zoom",
+            "type": "integer"
+          },
+          "min_zoom": {
+            "title": "Min Zoom",
+            "type": "integer"
+          },
+          "tile": {
+            "$ref": "#/components/schemas/TileTemplate"
+          },
+          "time_key": {
+            "title": "Time Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "layer",
+          "time_key",
+          "level_key",
+          "min_zoom",
+          "max_zoom",
+          "tile"
+        ],
+        "title": "BiasTileSetItem",
+        "type": "object"
+      },
+      "BiasTileSetsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "generated_at": {
+            "title": "Generated At",
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BiasTileSetItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "schema_version": {
+            "default": 1,
+            "title": "Schema Version",
+            "type": "integer"
+          }
+        },
+        "title": "BiasTileSetsResponse",
+        "type": "object"
+      },
       "CldasTimesResponse": {
         "additionalProperties": false,
         "properties": {
@@ -522,6 +590,95 @@
           }
         },
         "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "HistoricalStatisticItem": {
+        "additionalProperties": false,
+        "properties": {
+          "dataset_path": {
+            "title": "Dataset Path",
+            "type": "string"
+          },
+          "metadata_path": {
+            "title": "Metadata Path",
+            "type": "string"
+          },
+          "samples": {
+            "title": "Samples",
+            "type": "integer"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "tiles": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/TileTemplate"
+            },
+            "title": "Tiles",
+            "type": "object"
+          },
+          "variable": {
+            "title": "Variable",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          },
+          "window_end": {
+            "title": "Window End",
+            "type": "string"
+          },
+          "window_key": {
+            "title": "Window Key",
+            "type": "string"
+          },
+          "window_kind": {
+            "title": "Window Kind",
+            "type": "string"
+          },
+          "window_start": {
+            "title": "Window Start",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "variable",
+          "window_kind",
+          "window_key",
+          "version",
+          "window_start",
+          "window_end",
+          "samples",
+          "dataset_path",
+          "metadata_path"
+        ],
+        "title": "HistoricalStatisticItem",
+        "type": "object"
+      },
+      "HistoricalStatisticsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "generated_at": {
+            "title": "Generated At",
+            "type": "string"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/HistoricalStatisticItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "schema_version": {
+            "default": 1,
+            "title": "Schema Version",
+            "type": "integer"
+          }
+        },
+        "title": "HistoricalStatisticsResponse",
         "type": "object"
       },
       "IngestRun": {
@@ -1865,6 +2022,27 @@
         "title": "SampleResponse",
         "type": "object"
       },
+      "SnowStatisticsDefinitionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "definition": {
+            "additionalProperties": true,
+            "title": "Definition",
+            "type": "object"
+          },
+          "generated_at": {
+            "title": "Generated At",
+            "type": "string"
+          },
+          "schema_version": {
+            "default": 1,
+            "title": "Schema Version",
+            "type": "integer"
+          }
+        },
+        "title": "SnowStatisticsDefinitionResponse",
+        "type": "object"
+      },
       "ThresholdDirection": {
         "enum": [
           "ascending",
@@ -1891,6 +2069,25 @@
           "score"
         ],
         "title": "ThresholdScore",
+        "type": "object"
+      },
+      "TileTemplate": {
+        "additionalProperties": false,
+        "properties": {
+          "legend": {
+            "title": "Legend",
+            "type": "string"
+          },
+          "template": {
+            "title": "Template",
+            "type": "string"
+          }
+        },
+        "required": [
+          "template",
+          "legend"
+        ],
+        "title": "TileTemplate",
         "type": "object"
       },
       "ValidationError": {
@@ -2078,6 +2275,239 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/analytics/bias/tile-sets": {
+      "get": {
+        "operationId": "list_bias_tile_sets_api_v1_analytics_bias_tile_sets_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "layer",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Layer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fmt",
+            "required": false,
+            "schema": {
+              "default": "png",
+              "title": "Fmt",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BiasTileSetsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Bias Tile Sets",
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/historical/statistics": {
+      "get": {
+        "operationId": "list_historical_statistics_api_v1_analytics_historical_statistics_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "in": "query",
+            "name": "variable",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Variable"
+            }
+          },
+          {
+            "in": "query",
+            "name": "window_kind",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Window Kind"
+            }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Version"
+            }
+          },
+          {
+            "in": "query",
+            "name": "fmt",
+            "required": false,
+            "schema": {
+              "default": "png",
+              "title": "Fmt",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HistoricalStatisticsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Historical Statistics",
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
+    "/api/v1/analytics/snow/definition": {
+      "get": {
+        "operationId": "get_snow_statistics_definition_api_v1_analytics_snow_definition_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnowStatisticsDefinitionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Snow Statistics Definition",
+        "tags": [
+          "analytics"
+        ]
+      }
+    },
     "/api/v1/attribution": {
       "get": {
         "operationId": "attribution_api_v1_attribution_get",

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -15,6 +15,7 @@ from observability import (
 )
 from rate_limit import RateLimitMiddleware, create_redis_client
 from routers.attribution import router as attribution_router
+from routers.analytics import router as analytics_router
 from routers.catalog import router as catalog_router
 from routers.errors import router as errors_router
 from routers.effects import router as effects_router
@@ -73,6 +74,7 @@ def create_app() -> FastAPI:
 
     api_v1 = APIRouter(prefix="/api/v1")
     api_v1.include_router(effects_router)
+    api_v1.include_router(analytics_router)
     api_v1.include_router(attribution_router)
     api_v1.include_router(catalog_router)
     api_v1.include_router(local_data_router)

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 from .base import Base
 from .catalog import EcmwfAsset, EcmwfRun, EcmwfTime
 from .effect_trigger_logs import EffectTriggerLog
+from .monitoring_analytics import BiasTileSet, HistoricalStatisticArtifact
 from .products import Product, ProductHazard, ProductVersion
 from .risk_poi import RiskPOI
 
 __all__ = [
     "Base",
+    "BiasTileSet",
     "EcmwfAsset",
     "EcmwfRun",
     "EcmwfTime",
     "EffectTriggerLog",
+    "HistoricalStatisticArtifact",
     "Product",
     "ProductHazard",
     "ProductVersion",

--- a/apps/api/src/models/monitoring_analytics.py
+++ b/apps/api/src/models/monitoring_analytics.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Integer, JSON, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class HistoricalStatisticArtifact(Base):
+    __tablename__ = "historical_statistics"
+    __table_args__ = (
+        UniqueConstraint(
+            "source",
+            "variable",
+            "window_kind",
+            "window_key",
+            "version",
+            name="uq_historical_statistics_identity",
+        ),
+        Index("ix_historical_statistics_window_end", "window_end"),
+        Index("ix_historical_statistics_variable", "variable"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    variable: Mapped[str] = mapped_column(String(64), nullable=False)
+    window_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    window_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    version: Mapped[str] = mapped_column(String(32), nullable=False)
+
+    window_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    window_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    samples: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    dataset_path: Mapped[str] = mapped_column(String(2048), nullable=False)
+    metadata_path: Mapped[str] = mapped_column(String(2048), nullable=False)
+    extra: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class BiasTileSet(Base):
+    __tablename__ = "bias_tile_sets"
+    __table_args__ = (
+        UniqueConstraint(
+            "layer",
+            "time_key",
+            "level_key",
+            name="uq_bias_tile_sets_identity",
+        ),
+        Index("ix_bias_tile_sets_layer", "layer"),
+        Index("ix_bias_tile_sets_time_key", "time_key"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    layer: Mapped[str] = mapped_column(String(128), nullable=False)
+    time_key: Mapped[str] = mapped_column(String(32), nullable=False)
+    level_key: Mapped[str] = mapped_column(String(32), nullable=False)
+
+    min_zoom: Mapped[int] = mapped_column(Integer, nullable=False)
+    max_zoom: Mapped[int] = mapped_column(Integer, nullable=False)
+    formats: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+

--- a/apps/api/src/models/monitoring_analytics.py
+++ b/apps/api/src/models/monitoring_analytics.py
@@ -30,8 +30,12 @@ class HistoricalStatisticArtifact(Base):
     window_key: Mapped[str] = mapped_column(String(64), nullable=False)
     version: Mapped[str] = mapped_column(String(32), nullable=False)
 
-    window_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    window_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    window_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    window_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
     samples: Mapped[int] = mapped_column(Integer, nullable=False)
 
     dataset_path: Mapped[str] = mapped_column(String(2048), nullable=False)
@@ -68,4 +72,3 @@ class BiasTileSet(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-

--- a/apps/api/src/monitoring_analytics_index.py
+++ b/apps/api/src/monitoring_analytics_index.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+import db
+from models import Base, BiasTileSet, HistoricalStatisticArtifact
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    raw = (value or "").strip()
+    if raw == "":
+        raise ValueError("datetime must not be empty")
+    candidate = raw
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    dt = datetime.fromisoformat(candidate)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _iter_statistics_metadata_files(statistics_root: Path) -> Iterable[Path]:
+    if not statistics_root.is_dir():
+        return []
+    return statistics_root.rglob("statistics.nc.meta.json")
+
+
+def _load_json(path: Path) -> dict:
+    raw = path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError(f"metadata json must be an object: {path}")
+    return data
+
+
+def _upsert_historical_statistics(
+    session: Session, *, statistics_root: Path, metadata_path: Path
+) -> bool:
+    meta = _load_json(metadata_path)
+    source = str(meta.get("output_source") or meta.get("source_kind") or "").strip()
+    variable = str(meta.get("variable") or "").strip()
+    window_kind = str(meta.get("window_kind") or "").strip()
+    window_key = str(meta.get("window_key") or "").strip()
+    version = str(meta.get("version") or "").strip()
+
+    if not all((source, variable, window_kind, window_key, version)):
+        raise ValueError(f"missing required metadata fields: {metadata_path}")
+
+    window_start = _parse_iso_datetime(str(meta.get("window_start") or ""))
+    window_end = _parse_iso_datetime(str(meta.get("window_end") or ""))
+    samples = int(meta.get("samples") or 0)
+
+    dataset_path = metadata_path.name.replace(".meta.json", "")
+    dataset_rel = (
+        metadata_path.with_name(dataset_path)
+        .resolve()
+        .relative_to(statistics_root.resolve())
+        .as_posix()
+    )
+    metadata_rel = metadata_path.resolve().relative_to(statistics_root.resolve()).as_posix()
+
+    extra = dict(meta)
+
+    stmt = select(HistoricalStatisticArtifact).where(
+        HistoricalStatisticArtifact.source == source,
+        HistoricalStatisticArtifact.variable == variable,
+        HistoricalStatisticArtifact.window_kind == window_kind,
+        HistoricalStatisticArtifact.window_key == window_key,
+        HistoricalStatisticArtifact.version == version,
+    )
+    existing = session.execute(stmt).scalar_one_or_none()
+    if existing is None:
+        session.add(
+            HistoricalStatisticArtifact(
+                source=source,
+                variable=variable,
+                window_kind=window_kind,
+                window_key=window_key,
+                version=version,
+                window_start=window_start,
+                window_end=window_end,
+                samples=samples,
+                dataset_path=dataset_rel,
+                metadata_path=metadata_rel,
+                extra=extra,
+            )
+        )
+        return True
+
+    existing.window_start = window_start
+    existing.window_end = window_end
+    existing.samples = samples
+    existing.dataset_path = dataset_rel
+    existing.metadata_path = metadata_rel
+    existing.extra = extra
+    return False
+
+
+def index_historical_statistics(
+    session: Session, *, statistics_root: Path
+) -> tuple[int, int]:
+    created = 0
+    updated = 0
+
+    for meta_path in _iter_statistics_metadata_files(statistics_root):
+        was_created = _upsert_historical_statistics(
+            session, statistics_root=statistics_root, metadata_path=meta_path
+        )
+        if was_created:
+            created += 1
+        else:
+            updated += 1
+
+    return created, updated
+
+
+def _detect_formats(level_dir: Path) -> list[str]:
+    formats: list[str] = []
+    for ext in ("png", "webp"):
+        found = next(level_dir.rglob(f"*.{ext}"), None)
+        if found is not None and ext not in formats:
+            formats.append(ext)
+    return formats
+
+
+def _detect_zoom_range(level_dir: Path) -> tuple[int, int] | None:
+    zooms: list[int] = []
+    for child in level_dir.iterdir():
+        if not child.is_dir():
+            continue
+        if not child.name.isdigit():
+            continue
+        zooms.append(int(child.name))
+    if not zooms:
+        return None
+    return min(zooms), max(zooms)
+
+
+def index_bias_tiles(session: Session, *, tiles_root: Path) -> tuple[int, int]:
+    bias_root = tiles_root / "bias"
+    if not bias_root.is_dir():
+        return 0, 0
+
+    created = 0
+    updated = 0
+
+    for element_dir in sorted(bias_root.iterdir()):
+        if not element_dir.is_dir():
+            continue
+        layer = f"bias/{element_dir.name}"
+        for time_dir in sorted(element_dir.iterdir()):
+            if not time_dir.is_dir():
+                continue
+            time_key = time_dir.name
+            for level_dir in sorted(time_dir.iterdir()):
+                if not level_dir.is_dir():
+                    continue
+                level_key = level_dir.name
+
+                zoom_range = _detect_zoom_range(level_dir)
+                if zoom_range is None:
+                    continue
+                min_zoom, max_zoom = zoom_range
+                formats = _detect_formats(level_dir)
+                if not formats:
+                    continue
+
+                stmt = select(BiasTileSet).where(
+                    BiasTileSet.layer == layer,
+                    BiasTileSet.time_key == time_key,
+                    BiasTileSet.level_key == level_key,
+                )
+                existing = session.execute(stmt).scalar_one_or_none()
+                if existing is None:
+                    session.add(
+                        BiasTileSet(
+                            layer=layer,
+                            time_key=time_key,
+                            level_key=level_key,
+                            min_zoom=min_zoom,
+                            max_zoom=max_zoom,
+                            formats=formats,
+                        )
+                    )
+                    created += 1
+                else:
+                    existing.min_zoom = min_zoom
+                    existing.max_zoom = max_zoom
+                    existing.formats = formats
+                    updated += 1
+
+    return created, updated
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Index statistics artifacts and bias tiles into the API database."
+    )
+    parser.add_argument(
+        "--statistics-root",
+        default=None,
+        help="Root directory for statistics outputs (default: Data/statistics)",
+    )
+    parser.add_argument(
+        "--tiles-root",
+        default=None,
+        help="Root directory for tiles outputs (default: Data/tiles)",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="Optional SQLAlchemy DATABASE_URL override (otherwise uses app config)",
+    )
+    parser.add_argument(
+        "--only",
+        choices=("all", "statistics", "bias"),
+        default="all",
+        help="Index only a subset (default: all)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+
+    repo_root = Path(__file__).resolve().parents[3]
+    statistics_root = (
+        (repo_root / "Data" / "statistics")
+        if args.statistics_root is None
+        else Path(args.statistics_root)
+    ).resolve()
+    tiles_root = (
+        (repo_root / "Data" / "tiles") if args.tiles_root is None else Path(args.tiles_root)
+    ).resolve()
+
+    engine = create_engine(args.database_url) if args.database_url else db.get_engine()
+    Base.metadata.create_all(engine)
+
+    try:
+        with Session(engine) as session:
+            created_stats = updated_stats = 0
+            created_bias = updated_bias = 0
+
+            if args.only in {"all", "statistics"}:
+                created_stats, updated_stats = index_historical_statistics(
+                    session, statistics_root=statistics_root
+                )
+
+            if args.only in {"all", "bias"}:
+                created_bias, updated_bias = index_bias_tiles(session, tiles_root=tiles_root)
+
+            session.commit()
+
+        print(
+            json.dumps(
+                {
+                    "historical_statistics": {
+                        "created": created_stats,
+                        "updated": updated_stats,
+                    },
+                    "bias_tile_sets": {"created": created_bias, "updated": updated_bias},
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    except SQLAlchemyError as exc:
+        raise SystemExit(f"Database error: {exc}") from exc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/src/monitoring_analytics_index.py
+++ b/apps/api/src/monitoring_analytics_index.py
@@ -65,7 +65,9 @@ def _upsert_historical_statistics(
         .relative_to(statistics_root.resolve())
         .as_posix()
     )
-    metadata_rel = metadata_path.resolve().relative_to(statistics_root.resolve()).as_posix()
+    metadata_rel = (
+        metadata_path.resolve().relative_to(statistics_root.resolve()).as_posix()
+    )
 
     extra = dict(meta)
 
@@ -238,7 +240,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         else Path(args.statistics_root)
     ).resolve()
     tiles_root = (
-        (repo_root / "Data" / "tiles") if args.tiles_root is None else Path(args.tiles_root)
+        (repo_root / "Data" / "tiles")
+        if args.tiles_root is None
+        else Path(args.tiles_root)
     ).resolve()
 
     engine = create_engine(args.database_url) if args.database_url else db.get_engine()
@@ -255,7 +259,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
 
             if args.only in {"all", "bias"}:
-                created_bias, updated_bias = index_bias_tiles(session, tiles_root=tiles_root)
+                created_bias, updated_bias = index_bias_tiles(
+                    session, tiles_root=tiles_root
+                )
 
             session.commit()
 
@@ -266,7 +272,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "created": created_stats,
                         "updated": updated_stats,
                     },
-                    "bias_tile_sets": {"created": created_bias, "updated": updated_bias},
+                    "bias_tile_sets": {
+                        "created": created_bias,
+                        "updated": updated_bias,
+                    },
                 },
                 ensure_ascii=False,
             )

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -117,7 +117,9 @@ def list_historical_statistics(
     if variable:
         stmt = stmt.where(HistoricalStatisticArtifact.variable == variable.strip())
     if window_kind:
-        stmt = stmt.where(HistoricalStatisticArtifact.window_kind == window_kind.strip())
+        stmt = stmt.where(
+            HistoricalStatisticArtifact.window_kind == window_kind.strip()
+        )
     if version:
         stmt = stmt.where(HistoricalStatisticArtifact.version == version.strip())
     stmt = stmt.limit(limit).offset(offset)
@@ -176,7 +178,9 @@ class BiasTileSetsResponse(BaseModel):
     items: list[BiasTileSetItem] = Field(default_factory=list)
 
 
-def _bias_tile_template(*, layer: str, time_key: str, level_key: str, fmt: str) -> TileTemplate:
+def _bias_tile_template(
+    *, layer: str, time_key: str, level_key: str, fmt: str
+) -> TileTemplate:
     fmt_norm = (fmt or "").strip().lower() or "png"
     if fmt_norm not in {"png", "webp"}:
         raise HTTPException(status_code=400, detail="Unsupported format")
@@ -243,7 +247,9 @@ def get_snow_statistics_definition() -> SnowStatisticsDefinitionResponse:
     try:
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(status_code=500, detail="Failed to load snow statistics") from exc
+        raise HTTPException(
+            status_code=500, detail="Failed to load snow statistics"
+        ) from exc
     if data is None:
         data = {}
     if not isinstance(data, dict):

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import desc, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+import db
+from digital_earth_config.settings import _resolve_config_dir
+from models import BiasTileSet, HistoricalStatisticArtifact
+
+logger = logging.getLogger("api.error")
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _iso(dt: datetime) -> str:
+    parsed = dt
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TileTemplate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    template: str
+    legend: str
+
+
+class HistoricalStatisticItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    variable: str
+    window_kind: str
+    window_key: str
+    version: str
+    window_start: str
+    window_end: str
+    samples: int
+    dataset_path: str
+    metadata_path: str
+    tiles: dict[str, TileTemplate] = Field(default_factory=dict)
+
+
+class HistoricalStatisticsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = 1
+    generated_at: str = Field(default_factory=_utc_now_iso)
+    items: list[HistoricalStatisticItem] = Field(default_factory=list)
+
+
+def _stats_tile_prefix(
+    *, source: str, variable: str, stat: str, version: str, window_key: str
+) -> str:
+    src = (source or "").strip()
+    var = (variable or "").strip().lower()
+    stat_key = (stat or "").strip().lower()
+    ver = (version or "").strip()
+    key = (window_key or "").strip()
+    return f"statistics/{src}/{var}/{stat_key}/{ver}/{key}"
+
+
+def _stats_tile_templates(
+    *, source: str, variable: str, version: str, window_key: str, fmt: str
+) -> dict[str, TileTemplate]:
+    fmt_norm = (fmt or "").strip().lower() or "png"
+    if fmt_norm not in {"png", "webp"}:
+        raise HTTPException(status_code=400, detail="Unsupported format")
+
+    tiles: dict[str, TileTemplate] = {}
+    for stat in ("sum", "mean"):
+        prefix = _stats_tile_prefix(
+            source=source,
+            variable=variable,
+            stat=stat,
+            version=version,
+            window_key=window_key,
+        )
+        layer = "/".join(prefix.split("/")[:4])
+        tiles[stat] = TileTemplate(
+            template=f"/api/v1/tiles/{prefix}/{{z}}/{{x}}/{{y}}.{fmt_norm}",
+            legend=f"/api/v1/tiles/{layer}/legend.json",
+        )
+    return tiles
+
+
+@router.get("/historical/statistics", response_model=HistoricalStatisticsResponse)
+def list_historical_statistics(
+    source: Optional[str] = Query(default=None),
+    variable: Optional[str] = Query(default=None),
+    window_kind: Optional[str] = Query(default=None),
+    version: Optional[str] = Query(default=None),
+    fmt: str = Query(default="png"),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> HistoricalStatisticsResponse:
+    stmt = select(HistoricalStatisticArtifact).order_by(
+        desc(HistoricalStatisticArtifact.window_end)
+    )
+    if source:
+        stmt = stmt.where(HistoricalStatisticArtifact.source == source.strip())
+    if variable:
+        stmt = stmt.where(HistoricalStatisticArtifact.variable == variable.strip())
+    if window_kind:
+        stmt = stmt.where(HistoricalStatisticArtifact.window_kind == window_kind.strip())
+    if version:
+        stmt = stmt.where(HistoricalStatisticArtifact.version == version.strip())
+    stmt = stmt.limit(limit).offset(offset)
+
+    try:
+        with Session(db.get_engine()) as session:
+            rows = session.execute(stmt).scalars().all()
+    except SQLAlchemyError as exc:
+        logger.error("historical_statistics_db_error", extra={"error": str(exc)})
+        raise HTTPException(status_code=503, detail="Database unavailable") from exc
+
+    items: list[HistoricalStatisticItem] = []
+    for row in rows:
+        items.append(
+            HistoricalStatisticItem(
+                source=row.source,
+                variable=row.variable,
+                window_kind=row.window_kind,
+                window_key=row.window_key,
+                version=row.version,
+                window_start=_iso(row.window_start),
+                window_end=_iso(row.window_end),
+                samples=int(row.samples),
+                dataset_path=row.dataset_path,
+                metadata_path=row.metadata_path,
+                tiles=_stats_tile_templates(
+                    source=row.source,
+                    variable=row.variable,
+                    version=row.version,
+                    window_key=row.window_key,
+                    fmt=fmt,
+                ),
+            )
+        )
+
+    return HistoricalStatisticsResponse(items=items)
+
+
+class BiasTileSetItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    layer: str
+    time_key: str
+    level_key: str
+    min_zoom: int
+    max_zoom: int
+    formats: list[str] = Field(default_factory=list)
+    tile: TileTemplate
+
+
+class BiasTileSetsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = 1
+    generated_at: str = Field(default_factory=_utc_now_iso)
+    items: list[BiasTileSetItem] = Field(default_factory=list)
+
+
+def _bias_tile_template(*, layer: str, time_key: str, level_key: str, fmt: str) -> TileTemplate:
+    fmt_norm = (fmt or "").strip().lower() or "png"
+    if fmt_norm not in {"png", "webp"}:
+        raise HTTPException(status_code=400, detail="Unsupported format")
+    return TileTemplate(
+        template=f"/api/v1/tiles/{layer}/{time_key}/{level_key}/{{z}}/{{x}}/{{y}}.{fmt_norm}",
+        legend=f"/api/v1/tiles/{layer}/legend.json",
+    )
+
+
+@router.get("/bias/tile-sets", response_model=BiasTileSetsResponse)
+def list_bias_tile_sets(
+    layer: Optional[str] = Query(default=None),
+    fmt: str = Query(default="png"),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> BiasTileSetsResponse:
+    stmt = select(BiasTileSet).order_by(desc(BiasTileSet.time_key))
+    if layer:
+        stmt = stmt.where(BiasTileSet.layer == layer.strip())
+    stmt = stmt.limit(limit).offset(offset)
+
+    try:
+        with Session(db.get_engine()) as session:
+            rows = session.execute(stmt).scalars().all()
+    except SQLAlchemyError as exc:
+        logger.error("bias_tile_sets_db_error", extra={"error": str(exc)})
+        raise HTTPException(status_code=503, detail="Database unavailable") from exc
+
+    items: list[BiasTileSetItem] = []
+    for row in rows:
+        items.append(
+            BiasTileSetItem(
+                layer=row.layer,
+                time_key=row.time_key,
+                level_key=row.level_key,
+                min_zoom=int(row.min_zoom),
+                max_zoom=int(row.max_zoom),
+                formats=list(row.formats or []),
+                tile=_bias_tile_template(
+                    layer=row.layer,
+                    time_key=row.time_key,
+                    level_key=row.level_key,
+                    fmt=fmt,
+                ),
+            )
+        )
+    return BiasTileSetsResponse(items=items)
+
+
+class SnowStatisticsDefinitionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = 1
+    generated_at: str = Field(default_factory=_utc_now_iso)
+    definition: dict[str, Any] = Field(default_factory=dict)
+
+
+@router.get("/snow/definition", response_model=SnowStatisticsDefinitionResponse)
+def get_snow_statistics_definition() -> SnowStatisticsDefinitionResponse:
+    config_dir = _resolve_config_dir()
+    path = Path(config_dir) / "snow-statistics.yaml"
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="snow-statistics.yaml not found")
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail="Failed to load snow statistics") from exc
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=500, detail="Invalid snow statistics config")
+    payload = json.loads(json.dumps(data, ensure_ascii=False, default=str))
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=500, detail="Invalid snow statistics config")
+    return SnowStatisticsDefinitionResponse(definition=payload)

--- a/apps/api/src/routers/tiles.py
+++ b/apps/api/src/routers/tiles.py
@@ -521,7 +521,10 @@ def get_tile(
             else:
                 raise
 
-        headers: dict[str, str] = {"Cache-Control": _DEFAULT_CACHE_CONTROL, "ETag": etag}
+        headers: dict[str, str] = {
+            "Cache-Control": _DEFAULT_CACHE_CONTROL,
+            "ETag": etag,
+        }
 
         transformed = False
         if (

--- a/apps/api/tests/test_analytics_api.py
+++ b/apps/api/tests/test_analytics_api.py
@@ -104,9 +104,7 @@ def test_analytics_snow_definition_endpoint(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     db_url = f"sqlite+pysqlite:///{tmp_path / 'analytics.db'}"
-    client, _redis = _make_client(
-        monkeypatch, tmp_path, db_url=db_url
-    )
+    client, _redis = _make_client(monkeypatch, tmp_path, db_url=db_url)
     resp = client.get("/api/v1/analytics/snow/definition")
     assert resp.status_code == 200
     payload = resp.json()
@@ -203,7 +201,9 @@ def test_tiles_can_serve_from_local_filesystem(
         tiles_dir=tiles_root,
     )
 
-    ok = client.get("/api/v1/tiles/layer/0/0/0.json", headers={"Accept-Encoding": "gzip"})
+    ok = client.get(
+        "/api/v1/tiles/layer/0/0/0.json", headers={"Accept-Encoding": "gzip"}
+    )
     assert ok.status_code == 200
     assert ok.headers["content-encoding"] == "gzip"
     assert ok.headers["vary"] == "Accept-Encoding"

--- a/apps/api/tests/test_analytics_api.py
+++ b/apps/api/tests/test_analytics_api.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from redis_fakes import FakeRedis
+
+
+def _write_config(dir_path: Path, env: str, data: dict) -> None:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / f"{env}.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_yaml(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def _base_config(*, tiles_dir: str | None = None) -> dict:
+    storage: dict = {"tiles_bucket": "tiles", "raw_bucket": "raw"}
+    if tiles_dir is not None:
+        storage["tiles_dir"] = tiles_dir
+
+    return {
+        "api": {
+            "host": "0.0.0.0",
+            "port": 8000,
+            "debug": True,
+            "cors_origins": [],
+            "rate_limit": {"enabled": False},
+        },
+        "pipeline": {"workers": 2, "batch_size": 100, "data_source": "local"},
+        "web": {"api_base_url": "http://localhost:8000"},
+        "database": {"host": "localhost", "port": 5432, "name": "digital_earth"},
+        "redis": {"host": "localhost", "port": 6379},
+        "storage": storage,
+    }
+
+
+def _make_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    db_url: str,
+    tiles_dir: Path | None = None,
+) -> tuple[TestClient, FakeRedis]:
+    monkeypatch.chdir(tmp_path)
+
+    config_dir = tmp_path / "config"
+    _write_config(
+        config_dir,
+        "dev",
+        _base_config(tiles_dir=str(tiles_dir) if tiles_dir is not None else None),
+    )
+
+    _write_yaml(
+        config_dir / "snow-statistics.yaml",
+        "\n".join(
+            [
+                "schema_version: 1",
+                "windows:",
+                "  rolling_days: [7, 30]",
+                "metrics:",
+                "  - id: snowfall_sum",
+                "    source: snowfall_mm",
+                "    reducer: sum",
+                "    windows: rolling_days",
+                "    output_units: mm",
+                "",
+            ]
+        ),
+    )
+
+    monkeypatch.setenv("DIGITAL_EARTH_ENV", "dev")
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("DIGITAL_EARTH_DB_USER", "app")
+    monkeypatch.setenv("DIGITAL_EARTH_DB_PASSWORD", "secret")
+    monkeypatch.setenv("DATABASE_URL", db_url)
+
+    from config import get_settings
+    from db import get_engine
+    import main as main_module
+
+    get_settings.cache_clear()
+    get_engine.cache_clear()
+
+    from models import Base
+
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+    engine.dispose()
+
+    redis = FakeRedis(use_real_time=False)
+    monkeypatch.setattr(main_module, "create_redis_client", lambda _url: redis)
+    return TestClient(main_module.create_app()), redis
+
+
+def test_analytics_snow_definition_endpoint(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    db_url = f"sqlite+pysqlite:///{tmp_path / 'analytics.db'}"
+    client, _redis = _make_client(
+        monkeypatch, tmp_path, db_url=db_url
+    )
+    resp = client.get("/api/v1/analytics/snow/definition")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["schema_version"] == 1
+    assert payload["definition"]["schema_version"] == 1
+    assert payload["definition"]["windows"]["rolling_days"] == [7, 30]
+
+
+def test_analytics_historical_statistics_lists_items_and_templates(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    db_url = f"sqlite+pysqlite:///{tmp_path / 'analytics.db'}"
+    client, _redis = _make_client(monkeypatch, tmp_path, db_url=db_url)
+
+    from models import HistoricalStatisticArtifact
+
+    engine = create_engine(db_url)
+    with Session(engine) as session:
+        session.add(
+            HistoricalStatisticArtifact(
+                source="cldas",
+                variable="SNOWFALL",
+                window_kind="rolling_days",
+                window_key="20260108T000000Z-P7D",
+                version="v1",
+                window_start=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                window_end=datetime(2026, 1, 8, tzinfo=timezone.utc),
+                samples=168,
+                dataset_path="cldas/SNOWFALL/rolling_days/v1/20260108T000000Z-P7D/statistics.nc",
+                metadata_path="cldas/SNOWFALL/rolling_days/v1/20260108T000000Z-P7D/statistics.nc.meta.json",
+                extra={"schema_version": 1},
+            )
+        )
+        session.commit()
+
+    resp = client.get("/api/v1/analytics/historical/statistics?fmt=png")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["items"]) == 1
+    item = data["items"][0]
+    assert item["source"] == "cldas"
+    assert item["window_key"] == "20260108T000000Z-P7D"
+    assert "sum" in item["tiles"]
+    assert item["tiles"]["sum"]["template"].startswith(
+        "/api/v1/tiles/statistics/cldas/snowfall/sum/v1/20260108T000000Z-P7D/"
+    )
+
+
+def test_analytics_bias_tile_sets_lists_items_and_templates(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    db_url = f"sqlite+pysqlite:///{tmp_path / 'analytics.db'}"
+    client, _redis = _make_client(monkeypatch, tmp_path, db_url=db_url)
+
+    from models import BiasTileSet
+
+    engine = create_engine(db_url)
+    with Session(engine) as session:
+        session.add(
+            BiasTileSet(
+                layer="bias/temp",
+                time_key="20260101T000000Z",
+                level_key="sfc",
+                min_zoom=0,
+                max_zoom=6,
+                formats=["png"],
+            )
+        )
+        session.commit()
+
+    resp = client.get("/api/v1/analytics/bias/tile-sets?layer=bias/temp&fmt=png")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert len(payload["items"]) == 1
+    item = payload["items"][0]
+    assert item["layer"] == "bias/temp"
+    assert item["tile"]["template"].startswith(
+        "/api/v1/tiles/bias/temp/20260101T000000Z/sfc/"
+    )
+
+
+def test_tiles_can_serve_from_local_filesystem(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    tiles_root = tmp_path / "Data" / "tiles"
+    target = tiles_root / "layer" / "0" / "0" / "0.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x" * 2048, encoding="utf-8")
+
+    client, _redis = _make_client(
+        monkeypatch,
+        tmp_path,
+        db_url=f"sqlite+pysqlite:///{tmp_path / 'analytics.db'}",
+        tiles_dir=tiles_root,
+    )
+
+    ok = client.get("/api/v1/tiles/layer/0/0/0.json", headers={"Accept-Encoding": "gzip"})
+    assert ok.status_code == 200
+    assert ok.headers["content-encoding"] == "gzip"
+    assert ok.headers["vary"] == "Accept-Encoding"
+    assert ok.headers["cache-control"] == "public, max-age=3600"
+    assert ok.headers["etag"].startswith('"sha256-')
+
+    etag = ok.headers["etag"]
+    cached = client.get(
+        "/api/v1/tiles/layer/0/0/0.json",
+        headers={"If-None-Match": etag, "Accept-Encoding": "gzip;q=0"},
+    )
+    assert cached.status_code == 304

--- a/apps/api/tests/test_monitoring_analytics_index.py
+++ b/apps/api/tests/test_monitoring_analytics_index.py
@@ -10,7 +10,9 @@ from sqlalchemy.orm import Session
 
 def _write_json(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
 
 
 def test_indexer_upserts_historical_statistics(tmp_path: Path) -> None:
@@ -81,19 +83,14 @@ def test_indexer_upserts_bias_tiles(tmp_path: Path) -> None:
     tiles_root = tmp_path / "Data" / "tiles"
     (tiles_root / "bias").mkdir(parents=True, exist_ok=True)
     (tiles_root / "bias" / "README.txt").write_text("x", encoding="utf-8")
-    png = tiles_root / "bias" / "temp" / "20260101T000000Z" / "sfc" / "0" / "0" / "0.png"
+    png = (
+        tiles_root / "bias" / "temp" / "20260101T000000Z" / "sfc" / "0" / "0" / "0.png"
+    )
     png.parent.mkdir(parents=True, exist_ok=True)
     png.write_bytes(b"\x89PNG\r\n\x1a\n")
 
     webp = (
-        tiles_root
-        / "bias"
-        / "temp"
-        / "20260101T000000Z"
-        / "sfc"
-        / "1"
-        / "0"
-        / "0.webp"
+        tiles_root / "bias" / "temp" / "20260101T000000Z" / "sfc" / "1" / "0" / "0.webp"
     )
     webp.parent.mkdir(parents=True, exist_ok=True)
     webp.write_bytes(b"RIFF....WEBP")
@@ -139,7 +136,11 @@ def test_indexer_main_runs_with_database_url(tmp_path: Path) -> None:
 
 
 def test_indexer_helpers_cover_error_branches(tmp_path: Path) -> None:
-    from monitoring_analytics_index import _detect_zoom_range, _load_json, _parse_iso_datetime
+    from monitoring_analytics_index import (
+        _detect_zoom_range,
+        _load_json,
+        _parse_iso_datetime,
+    )
 
     with pytest.raises(ValueError, match="must not be empty"):
         _parse_iso_datetime("")

--- a/apps/api/tests/test_monitoring_analytics_index.py
+++ b/apps/api/tests/test_monitoring_analytics_index.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def test_indexer_upserts_historical_statistics(tmp_path: Path) -> None:
+    from monitoring_analytics_index import index_historical_statistics
+    from models import Base, HistoricalStatisticArtifact
+
+    db_url = f"sqlite+pysqlite:///{tmp_path / 'idx.db'}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+
+    statistics_root = tmp_path / "Data" / "statistics"
+    meta_path = (
+        statistics_root
+        / "cldas"
+        / "SNOWFALL"
+        / "rolling_days"
+        / "v1"
+        / "20260108T000000Z-P7D"
+        / "statistics.nc.meta.json"
+    )
+    _write_json(
+        meta_path,
+        {
+            "schema_version": 1,
+            "source_kind": "cldas",
+            "output_source": "cldas",
+            "variable": "SNOWFALL",
+            "window_kind": "rolling_days",
+            "window_key": "20260108T000000Z-P7D",
+            "window_start": "2026-01-01T00:00:00Z",
+            "window_end": "2026-01-08T00:00:00Z",
+            "samples": 168,
+            "version": "v1",
+        },
+    )
+
+    with Session(engine) as session:
+        created, updated = index_historical_statistics(
+            session, statistics_root=statistics_root
+        )
+        session.commit()
+        assert created == 1
+        assert updated == 0
+
+        created2, updated2 = index_historical_statistics(
+            session, statistics_root=statistics_root
+        )
+        session.commit()
+        assert created2 == 0
+        assert updated2 == 1
+
+        row = session.execute(select(HistoricalStatisticArtifact)).scalar_one()
+        assert row.source == "cldas"
+        assert row.variable == "SNOWFALL"
+        assert row.window_key == "20260108T000000Z-P7D"
+        assert row.dataset_path.endswith("/statistics.nc")
+        assert row.metadata_path.endswith("/statistics.nc.meta.json")
+
+
+def test_indexer_upserts_bias_tiles(tmp_path: Path) -> None:
+    from monitoring_analytics_index import index_bias_tiles
+    from models import Base, BiasTileSet
+
+    db_url = f"sqlite+pysqlite:///{tmp_path / 'idx.db'}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+
+    tiles_root = tmp_path / "Data" / "tiles"
+    (tiles_root / "bias").mkdir(parents=True, exist_ok=True)
+    (tiles_root / "bias" / "README.txt").write_text("x", encoding="utf-8")
+    png = tiles_root / "bias" / "temp" / "20260101T000000Z" / "sfc" / "0" / "0" / "0.png"
+    png.parent.mkdir(parents=True, exist_ok=True)
+    png.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    webp = (
+        tiles_root
+        / "bias"
+        / "temp"
+        / "20260101T000000Z"
+        / "sfc"
+        / "1"
+        / "0"
+        / "0.webp"
+    )
+    webp.parent.mkdir(parents=True, exist_ok=True)
+    webp.write_bytes(b"RIFF....WEBP")
+
+    with Session(engine) as session:
+        created, updated = index_bias_tiles(session, tiles_root=tiles_root)
+        session.commit()
+        assert created == 1
+        assert updated == 0
+
+        created2, updated2 = index_bias_tiles(session, tiles_root=tiles_root)
+        session.commit()
+        assert created2 == 0
+        assert updated2 == 1
+
+        row = session.execute(select(BiasTileSet)).scalar_one()
+        assert row.layer == "bias/temp"
+        assert row.time_key == "20260101T000000Z"
+        assert row.level_key == "sfc"
+        assert row.min_zoom == 0
+        assert row.max_zoom == 1
+        assert set(row.formats) == {"png", "webp"}
+
+
+def test_indexer_main_runs_with_database_url(tmp_path: Path) -> None:
+    from monitoring_analytics_index import main
+
+    db_url = f"sqlite+pysqlite:///{tmp_path / 'idx.db'}"
+    statistics_root = tmp_path / "stats"
+    tiles_root = tmp_path / "tiles"
+
+    code = main(
+        [
+            "--database-url",
+            db_url,
+            "--statistics-root",
+            str(statistics_root),
+            "--tiles-root",
+            str(tiles_root),
+        ]
+    )
+    assert code == 0
+
+
+def test_indexer_helpers_cover_error_branches(tmp_path: Path) -> None:
+    from monitoring_analytics_index import _detect_zoom_range, _load_json, _parse_iso_datetime
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        _parse_iso_datetime("")
+    parsed = _parse_iso_datetime("2026-01-01T00:00:00")
+    assert parsed.tzinfo is not None
+
+    bad_json = tmp_path / "bad.json"
+    bad_json.write_text("[1,2,3]", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be an object"):
+        _load_json(bad_json)
+
+    level_dir = tmp_path / "level"
+    level_dir.mkdir()
+    (level_dir / "not-a-dir.txt").write_text("x", encoding="utf-8")
+    (level_dir / "x").mkdir()
+    assert _detect_zoom_range(level_dir) is None
+
+
+def test_index_bias_tiles_returns_empty_when_bias_root_missing(tmp_path: Path) -> None:
+    from monitoring_analytics_index import index_bias_tiles
+    from models import Base
+
+    db_url = f"sqlite+pysqlite:///{tmp_path / 'idx.db'}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as session:
+        created, updated = index_bias_tiles(session, tiles_root=tmp_path / "no-tiles")
+        session.commit()
+        assert created == 0
+        assert updated == 0

--- a/config/snow-statistics.yaml
+++ b/config/snow-statistics.yaml
@@ -54,6 +54,12 @@ metrics:
     windows: rolling_days
     output_units: mm
 
+  - id: snow_depth_mean
+    source: snow_depth_cm
+    reducer: mean
+    windows: rolling_days
+    output_units: cm
+
   - id: snow_depth_max
     source: snow_depth_cm
     reducer: max
@@ -73,4 +79,3 @@ metrics:
     climatology: true
     windows: rolling_days
     output_units: percentile
-

--- a/packages/config/src/digital_earth_config/settings.py
+++ b/packages/config/src/digital_earth_config/settings.py
@@ -323,6 +323,7 @@ class StorageSettings(BaseModel):
     endpoint_url: Optional[str] = None
     region_name: Optional[str] = None
     tiles_base_url: Optional[str] = None
+    tiles_dir: Optional[Path] = None
     access_key_id: Optional[SecretStr] = Field(default=None, repr=False)
     secret_access_key: Optional[SecretStr] = Field(default=None, repr=False)
 

--- a/services/data-pipeline/scripts/run_snow_statistics.py
+++ b/services/data-pipeline/scripts/run_snow_statistics.py
@@ -179,18 +179,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             cldas_root = cfg.sources.cldas.root_dir
         else:
             cldas_root = get_local_data_paths().cldas_dir
-        source = CldasDirectorySource(cldas_root, engine=engine or cfg.sources.cldas.engine)
+        source = CldasDirectorySource(
+            cldas_root, engine=engine or cfg.sources.cldas.engine
+        )
         source_name = "cldas"
     else:
         dataset_path = args.archive_dataset or cfg.sources.archive.dataset_path
         if dataset_path is None:
             raise ValueError("--archive-dataset is required when --source=archive")
-        source = ArchiveDatasetSource(dataset_path, engine=engine or cfg.sources.archive.engine)
+        source = ArchiveDatasetSource(
+            dataset_path, engine=engine or cfg.sources.archive.engine
+        )
         source_name = "archive"
 
     version = str(args.version or cfg.output.version).strip() or "v1"
     output_dir = Path(args.output_dir) if args.output_dir else cfg.output.root_dir
-    tiles_dir = Path(args.tiles_output_dir) if args.tiles_output_dir else cfg.tiles.root_dir
+    tiles_dir = (
+        Path(args.tiles_output_dir) if args.tiles_output_dir else cfg.tiles.root_dir
+    )
 
     store = StatisticsStore(output_dir)
 

--- a/services/data-pipeline/scripts/run_snow_statistics.py
+++ b/services/data-pipeline/scripts/run_snow_statistics.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Sequence
+
+
+PIPELINE_SRC = Path(__file__).resolve().parents[1] / "src"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIG_SRC = REPO_ROOT / "packages" / "config" / "src"
+
+sys.path.insert(0, str(CONFIG_SRC))
+sys.path.insert(0, str(PIPELINE_SRC))
+
+
+def _utc_now_hour() -> datetime:
+    return datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+
+
+def _parse_csv_ints(values: Sequence[str]) -> list[int]:
+    items: list[int] = []
+    for raw in values:
+        parts = [part.strip() for part in str(raw or "").split(",") if part.strip()]
+        for part in parts:
+            items.append(int(part))
+    return items
+
+
+def _load_default_days_from_config() -> list[int] | None:
+    cfg_path = REPO_ROOT / "config" / "snow-statistics.yaml"
+    if not cfg_path.is_file():
+        return None
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except Exception:
+        return None
+
+    try:
+        raw = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    windows = raw.get("windows")
+    if not isinstance(windows, dict):
+        return None
+    rolling = windows.get("rolling_days")
+    if not isinstance(rolling, list):
+        return None
+    out: list[int] = []
+    for value in rolling:
+        try:
+            days = int(value)
+        except (TypeError, ValueError):
+            continue
+        if days > 0 and days not in out:
+            out.append(days)
+    return out or None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Batch compute snow historical statistics (snowfall sum + snow depth mean) "
+            "for rolling day windows and optionally generate tiles."
+        )
+    )
+    parser.add_argument(
+        "--source",
+        choices=("cldas", "archive"),
+        default="cldas",
+        help="Input source (default: cldas)",
+    )
+    parser.add_argument(
+        "--snowfall-variable",
+        required=True,
+        help="Dataset variable name for snowfall amount (e.g., SNOWFALL, PRE)",
+    )
+    parser.add_argument(
+        "--snow-depth-variable",
+        required=True,
+        help="Dataset variable name for snow depth (e.g., SD, SNOWH)",
+    )
+    parser.add_argument(
+        "--end",
+        default=None,
+        help="Window end time (UTC) ISO8601; defaults to current UTC hour",
+    )
+    parser.add_argument(
+        "--days",
+        action="append",
+        default=[],
+        help="Rolling window sizes in days; may be repeated or comma-separated",
+    )
+    parser.add_argument("--engine", default=None, help="Optional xarray engine")
+
+    parser.add_argument("--cldas-root", default=None, help="Optional CLDAS root dir")
+    parser.add_argument(
+        "--archive-dataset",
+        default=None,
+        help="Archive dataset path (required when --source=archive)",
+    )
+
+    parser.add_argument("--output-dir", default=None, help="Statistics output root")
+    parser.add_argument("--tiles-output-dir", default=None, help="Tiles output root")
+    parser.add_argument("--version", default=None, help="Output version tag")
+
+    parser.add_argument(
+        "--tiles",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Generate tiles (default: enabled)",
+    )
+    parser.add_argument(
+        "--format",
+        dest="formats",
+        action="append",
+        default=[],
+        help="Tile format(s): png, webp. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Print planned windows without running computation",
+    )
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    from digital_earth_config.local_data import get_local_data_paths
+    from statistics.batch import run_historical_statistics
+    from statistics.config import get_statistics_config
+    from statistics.sources import ArchiveDatasetSource, CldasDirectorySource
+    from statistics.storage import StatisticsStore
+    from statistics.tiles import StatisticsTileGenerator
+    from statistics.time_windows import TimeWindow, parse_time
+
+    import xarray as xr
+
+    cfg = get_statistics_config()
+
+    end = _utc_now_hour() if args.end is None else parse_time(args.end)
+    end = end.astimezone(timezone.utc)
+
+    days = _parse_csv_ints(tuple(args.days))
+    if not days:
+        days = _load_default_days_from_config() or [7, 30, 90]
+    days = sorted({int(d) for d in days if int(d) > 0})
+
+    windows = [
+        TimeWindow(kind="rolling_days", start=end - timedelta(days=day), end=end)
+        for day in days
+    ]
+
+    if args.dry_run:
+        for window in windows:
+            print(
+                json.dumps(
+                    {
+                        "kind": window.kind,
+                        "key": window.key,
+                        "start": window.start_iso,
+                        "end": window.end_iso,
+                    },
+                    ensure_ascii=False,
+                )
+            )
+        return 0
+
+    engine = str(args.engine).strip() if args.engine else None
+
+    if args.source == "cldas":
+        if args.cldas_root:
+            cldas_root = Path(args.cldas_root)
+        elif cfg.sources.cldas.root_dir is not None:
+            cldas_root = cfg.sources.cldas.root_dir
+        else:
+            cldas_root = get_local_data_paths().cldas_dir
+        source = CldasDirectorySource(cldas_root, engine=engine or cfg.sources.cldas.engine)
+        source_name = "cldas"
+    else:
+        dataset_path = args.archive_dataset or cfg.sources.archive.dataset_path
+        if dataset_path is None:
+            raise ValueError("--archive-dataset is required when --source=archive")
+        source = ArchiveDatasetSource(dataset_path, engine=engine or cfg.sources.archive.engine)
+        source_name = "archive"
+
+    version = str(args.version or cfg.output.version).strip() or "v1"
+    output_dir = Path(args.output_dir) if args.output_dir else cfg.output.root_dir
+    tiles_dir = Path(args.tiles_output_dir) if args.tiles_output_dir else cfg.tiles.root_dir
+
+    store = StatisticsStore(output_dir)
+
+    results = []
+    for variable in (str(args.snowfall_variable), str(args.snow_depth_variable)):
+        results.extend(
+            run_historical_statistics(
+                source=source,
+                variable=variable,
+                windows=windows,
+                store=store,
+                output_source_name=source_name,
+                version=version,
+                percentiles=[],
+                exact_percentiles_max_samples=0,
+            )
+        )
+
+    if not bool(args.tiles):
+        for item in results:
+            print(
+                json.dumps(
+                    {
+                        "dataset_path": str(item.artifact.dataset_path),
+                        "metadata_path": str(item.artifact.metadata_path),
+                        "window_key": item.window.key,
+                        "version": version,
+                        "samples": item.samples,
+                    },
+                    ensure_ascii=False,
+                )
+            )
+        return 0
+
+    formats_raw: list[str] = []
+    for raw in args.formats:
+        formats_raw.extend([p.strip() for p in str(raw or "").split(",") if p.strip()])
+    formats = formats_raw or list(cfg.tiles.formats)
+
+    for item in results:
+        var_lower = item.artifact.dataset_path.parents[3].name.lower()
+        with xr.open_dataset(item.artifact.dataset_path, engine="h5netcdf") as ds:
+            ds.load()
+
+            tile_var = (
+                "sum"
+                if var_lower == str(args.snowfall_variable).strip().lower()
+                else "mean"
+            )
+            layer = "/".join(
+                [
+                    str(cfg.tiles.layer_prefix or "statistics").strip() or "statistics",
+                    source_name,
+                    str(var_lower),
+                    tile_var,
+                ]
+            )
+            generator = StatisticsTileGenerator(ds, variable=tile_var, layer=layer)
+            result = generator.generate(
+                tiles_dir,
+                version=version,
+                window_key=item.window.key,
+                formats=formats,
+                legend_filename=str(cfg.tiles.legend_filename or "legend.json"),
+            )
+            print(json.dumps(result.__dict__, ensure_ascii=False, default=str))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/data-pipeline/src/statistics/accumulator.py
+++ b/services/data-pipeline/src/statistics/accumulator.py
@@ -22,6 +22,7 @@ def _validate_percentiles(percentiles: Sequence[float]) -> tuple[float, ...]:
 @dataclass(frozen=True)
 class GridStats:
     count: np.ndarray
+    sum: np.ndarray
     mean: np.ndarray
     min: np.ndarray
     max: np.ndarray
@@ -253,6 +254,7 @@ class GridStatisticsAccumulator:
 
         return GridStats(
             count=count,
+            sum=sum_.astype(np.float32, copy=False),
             mean=mean.astype(np.float32, copy=False),
             min=self._min.reshape(self._shape),
             max=self._max.reshape(self._shape),

--- a/services/data-pipeline/src/statistics/batch.py
+++ b/services/data-pipeline/src/statistics/batch.py
@@ -137,6 +137,7 @@ def compute_window_statistics(
     result = acc.finalize()
 
     stats: dict[str, np.ndarray] = {
+        "sum": result.sum,
         "mean": result.mean,
         "min": result.min,
         "max": result.max,

--- a/services/data-pipeline/src/statistics/cli.py
+++ b/services/data-pipeline/src/statistics/cli.py
@@ -81,9 +81,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--window-kind",
-        choices=("monthly", "seasonal", "annual"),
+        choices=("monthly", "seasonal", "annual", "range"),
         required=True,
-        help="Time window kind: monthly/seasonal/annual",
+        help="Time window kind: monthly/seasonal/annual/range",
     )
 
     parser.add_argument(

--- a/services/data-pipeline/src/statistics/time_windows.py
+++ b/services/data-pipeline/src/statistics/time_windows.py
@@ -119,7 +119,9 @@ class TimeWindow:
             days_f = delta_s / 86400.0
             days = int(round(days_f))
             if days <= 0 or abs(days_f - float(days)) > 1e-6:
-                raise ValueError("rolling_days windows must span an integer number of days")
+                raise ValueError(
+                    "rolling_days windows must span an integer number of days"
+                )
             return f"{_time_key(self.end)}-P{days}D"
         raise ValueError(f"Unsupported window kind: {self.kind}")
 

--- a/services/data-pipeline/src/statistics/time_windows.py
+++ b/services/data-pipeline/src/statistics/time_windows.py
@@ -6,7 +6,7 @@ from typing import Iterable, Literal
 
 import numpy as np
 
-TimeWindowKind = Literal["monthly", "seasonal", "annual"]
+TimeWindowKind = Literal["monthly", "seasonal", "annual", "range", "rolling_days"]
 
 
 def parse_time(value: object) -> datetime:
@@ -38,6 +38,8 @@ def parse_time(value: object) -> datetime:
 
 
 def _validate_aligned(dt: datetime, *, kind: TimeWindowKind) -> None:
+    if kind in {"range", "rolling_days"}:
+        return
     if dt.tzinfo is None:
         raise ValueError("time must be timezone-aware")
     dt = dt.astimezone(timezone.utc)
@@ -62,6 +64,10 @@ def _validate_aligned(dt: datetime, *, kind: TimeWindowKind) -> None:
         return
 
     raise ValueError(f"Unsupported window kind: {kind}")
+
+
+def _time_key(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
 def _add_months(dt: datetime, months: int) -> datetime:
@@ -106,6 +112,15 @@ class TimeWindow:
             return start.strftime("%Y")
         if self.kind == "seasonal":
             return _season_key(self.start)
+        if self.kind == "range":
+            return f"{_time_key(self.start)}_{_time_key(self.end)}"
+        if self.kind == "rolling_days":
+            delta_s = (self.end - self.start).total_seconds()
+            days_f = delta_s / 86400.0
+            days = int(round(days_f))
+            if days <= 0 or abs(days_f - float(days)) > 1e-6:
+                raise ValueError("rolling_days windows must span an integer number of days")
+            return f"{_time_key(self.end)}-P{days}D"
         raise ValueError(f"Unsupported window kind: {self.kind}")
 
     @property
@@ -128,6 +143,10 @@ def iter_time_windows(
 
     if end_dt <= start_dt:
         raise ValueError("end must be after start")
+
+    if kind in {"range", "rolling_days"}:
+        yield TimeWindow(kind=kind, start=start_dt, end=end_dt)
+        return
 
     _validate_aligned(start_dt, kind=kind)
     _validate_aligned(end_dt, kind=kind)

--- a/services/data-pipeline/tests/test_statistics_accumulator.py
+++ b/services/data-pipeline/tests/test_statistics_accumulator.py
@@ -16,6 +16,7 @@ def test_grid_statistics_accumulator_basic_stats() -> None:
     result = acc.finalize()
 
     assert result.count.tolist() == [[2, 1], [1, 2]]
+    np.testing.assert_allclose(result.sum, [[3.0, 2.0], [3.0, 4.0]], rtol=0, atol=1e-6)
     np.testing.assert_allclose(result.mean, [[1.5, 2.0], [3.0, 2.0]], rtol=0, atol=1e-6)
     np.testing.assert_allclose(result.min, [[1.0, 2.0], [3.0, 0.0]], rtol=0, atol=1e-6)
     np.testing.assert_allclose(result.max, [[2.0, 2.0], [3.0, 4.0]], rtol=0, atol=1e-6)

--- a/services/data-pipeline/tests/test_statistics_sources_batch_tiles_cli.py
+++ b/services/data-pipeline/tests/test_statistics_sources_batch_tiles_cli.py
@@ -173,6 +173,7 @@ def test_run_historical_statistics_writes_netcdf_and_metadata(tmp_path: Path) ->
         assert ds.attrs["version"] == "vtest"
         assert ds.attrs["window_key"] == "202001"
         assert ds["mean"].shape == (2, 2)
+        assert float(ds["sum"].values[0, 0]) == pytest.approx(21.0)
         assert float(ds["mean"].values[0, 0]) == pytest.approx(3.5)
         assert float(ds["p50"].values[0, 0]) == pytest.approx(3.5)
         assert int(ds["count"].values[0, 0]) == 6

--- a/services/data-pipeline/tests/test_statistics_time_windows.py
+++ b/services/data-pipeline/tests/test_statistics_time_windows.py
@@ -67,6 +67,33 @@ def test_iter_time_windows_annual_keys() -> None:
     assert [w.key for w in windows] == ["2020", "2021"]
 
 
+def test_iter_time_windows_range_accepts_arbitrary_bounds() -> None:
+    from statistics.time_windows import iter_time_windows
+
+    windows = list(
+        iter_time_windows(
+            kind="range",
+            start="2020-01-01T12:00:00Z",
+            end="2020-01-02T12:30:00Z",
+        )
+    )
+    assert len(windows) == 1
+    assert windows[0].key == "20200101T120000Z_20200102T123000Z"
+    assert windows[0].start_iso == "2020-01-01T12:00:00Z"
+    assert windows[0].end_iso == "2020-01-02T12:30:00Z"
+
+
+def test_time_window_key_rolling_days_formats_like_duration() -> None:
+    from statistics.time_windows import TimeWindow
+
+    window = TimeWindow(
+        kind="rolling_days",
+        start=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        end=datetime(2020, 1, 8, tzinfo=timezone.utc),
+    )
+    assert window.key == "20200108T000000Z-P7D"
+
+
 def test_iter_time_windows_rejects_misaligned_inputs() -> None:
     from statistics.time_windows import iter_time_windows
 


### PR DESCRIPTION
## Summary
实现历史统计和差值分析数据处理与 API

## Epic Stories
- ST-0057: 历史降雪/积雪统计指标定义
- ST-0058: 历史统计计算任务（批处理）
- ST-0059: 监测-预报差值图层（bias）

## Changes

### Data Pipeline
- 扩展统计量：sum 聚合（降雪量累计）
- 时间窗口：range + rolling_days
- Snow 统计配置：snow-statistics.yaml
- 批处理脚本：run_snow_statistics.py

### Backend API
- 新增 analytics router
- 3 个新端点：snow/definition, historical/statistics, bias/tile-sets
- PostgreSQL 元数据存储
- 本地文件系统瓦片服务

### Database
- 新增 monitoring_analytics 表
- 数据库迁移脚本
- 元数据索引脚本

## Test Plan
- [x] Data pipeline 测试 >= 90%
- [x] API 测试 >= 90%
- [x] 数据库迁移测试
- [x] Python lint 通过

Closes #13