### PR TITLE
[ST-0060] 事件模式中加入"历史/差值"切换UI (#91)

### DIFF
--- a/apps/web/src/features/analytics/analyticsApi.test.ts
+++ b/apps/web/src/features/analytics/analyticsApi.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import {
+  clearAnalyticsCache,
+  fetchBiasTileSets,
+  fetchHistoricalStatistics,
+} from './analyticsApi';
+
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  clearAnalyticsCache();
+  vi.unstubAllGlobals();
+});
+
+test('fetchHistoricalStatistics parses items and caches responses', async () => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    expect(url).toContain('/api/v1/analytics/historical/statistics');
+    expect(url).toContain('fmt=png');
+
+    return jsonResponse({
+      schema_version: 1,
+      generated_at: '2026-01-01T00:00:00Z',
+      items: [
+        {
+          source: ' cldas ',
+          variable: 'SNOWFALL',
+          window_kind: 'rolling_days',
+          window_key: '20260101T000000Z-P7D',
+          version: 'v1',
+          window_start: '2025-12-25T00:00:00Z',
+          window_end: '2026-01-01T00:00:00Z',
+          samples: 168,
+          dataset_path: 'x.nc',
+          metadata_path: 'x.meta.json',
+          tiles: {
+            mean: {
+              template:
+                '/api/v1/tiles/statistics/cldas/snowfall/mean/v1/20260101T000000Z-P7D/{z}/{x}/{y}.png',
+              legend: '/api/v1/tiles/statistics/cldas/snowfall/legend.json',
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  const first = await fetchHistoricalStatistics({ apiBaseUrl: 'http://api.test', fmt: 'png' });
+  expect(first.items).toHaveLength(1);
+  expect(first.items[0]?.source).toBe('cldas');
+  expect(first.items[0]?.tiles.mean?.template).toContain('/api/v1/tiles/statistics/');
+
+  const second = await fetchHistoricalStatistics({ apiBaseUrl: 'http://api.test', fmt: 'png' });
+  expect(second.items).toHaveLength(1);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test('fetchBiasTileSets parses items and honors the layer filter', async () => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    expect(url).toContain('/api/v1/analytics/bias/tile-sets');
+    expect(url).toContain('layer=bias%2Ftemp');
+
+    return jsonResponse({
+      schema_version: 1,
+      generated_at: '2026-01-01T00:00:00Z',
+      items: [
+        {
+          layer: 'bias/temp',
+          time_key: '20260101T000000Z',
+          level_key: 'sfc',
+          min_zoom: 0,
+          max_zoom: 6,
+          formats: ['png', 'webp'],
+          tile: {
+            template: '/api/v1/tiles/bias/temp/20260101T000000Z/sfc/{z}/{x}/{y}.png',
+            legend: '/api/v1/tiles/bias/temp/legend.json',
+          },
+        },
+      ],
+    });
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  const response = await fetchBiasTileSets({ apiBaseUrl: 'http://api.test', layer: 'bias/temp' });
+  expect(response.items).toHaveLength(1);
+  expect(response.items[0]?.layer).toBe('bias/temp');
+  expect(response.items[0]?.formats).toEqual(['png', 'webp']);
+});
+

--- a/apps/web/src/features/analytics/analyticsApi.test.ts
+++ b/apps/web/src/features/analytics/analyticsApi.test.ts
@@ -23,6 +23,10 @@ test('fetchHistoricalStatistics parses items and caches responses', async () => 
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     expect(url).toContain('/api/v1/analytics/historical/statistics');
     expect(url).toContain('fmt=png');
+    expect(url).toContain('source=cldas');
+    expect(url).toContain('variable=SNOWFALL');
+    expect(url).toContain('window_kind=rolling_days');
+    expect(url).toContain('limit=10');
 
     return jsonResponse({
       schema_version: 1,
@@ -53,12 +57,26 @@ test('fetchHistoricalStatistics parses items and caches responses', async () => 
 
   vi.stubGlobal('fetch', fetchMock);
 
-  const first = await fetchHistoricalStatistics({ apiBaseUrl: 'http://api.test', fmt: 'png' });
+  const first = await fetchHistoricalStatistics({
+    apiBaseUrl: 'http://api.test',
+    fmt: 'png',
+    source: 'cldas',
+    variable: 'SNOWFALL',
+    window_kind: 'rolling_days',
+    limit: 10,
+  });
   expect(first.items).toHaveLength(1);
   expect(first.items[0]?.source).toBe('cldas');
   expect(first.items[0]?.tiles.mean?.template).toContain('/api/v1/tiles/statistics/');
 
-  const second = await fetchHistoricalStatistics({ apiBaseUrl: 'http://api.test', fmt: 'png' });
+  const second = await fetchHistoricalStatistics({
+    apiBaseUrl: 'http://api.test',
+    fmt: 'png',
+    source: 'cldas',
+    variable: 'SNOWFALL',
+    window_kind: 'rolling_days',
+    limit: 10,
+  });
   expect(second.items).toHaveLength(1);
   expect(fetchMock).toHaveBeenCalledTimes(1);
 });
@@ -68,6 +86,7 @@ test('fetchBiasTileSets parses items and honors the layer filter', async () => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     expect(url).toContain('/api/v1/analytics/bias/tile-sets');
     expect(url).toContain('layer=bias%2Ftemp');
+    expect(url).toContain('limit=12');
 
     return jsonResponse({
       schema_version: 1,
@@ -91,9 +110,12 @@ test('fetchBiasTileSets parses items and honors the layer filter', async () => {
 
   vi.stubGlobal('fetch', fetchMock);
 
-  const response = await fetchBiasTileSets({ apiBaseUrl: 'http://api.test', layer: 'bias/temp' });
+  const response = await fetchBiasTileSets({
+    apiBaseUrl: 'http://api.test',
+    layer: 'bias/temp',
+    limit: 12,
+  });
   expect(response.items).toHaveLength(1);
   expect(response.items[0]?.layer).toBe('bias/temp');
   expect(response.items[0]?.formats).toEqual(['png', 'webp']);
 });
-

--- a/apps/web/src/features/analytics/analyticsApi.ts
+++ b/apps/web/src/features/analytics/analyticsApi.ts
@@ -1,0 +1,309 @@
+import { fetchJson, isHttpError } from '../../lib/http';
+
+export type TileTemplate = {
+  template: string;
+  legend: string;
+};
+
+export type HistoricalStatisticItem = {
+  source: string;
+  variable: string;
+  window_kind: string;
+  window_key: string;
+  version: string;
+  window_start: string;
+  window_end: string;
+  samples: number;
+  dataset_path: string;
+  metadata_path: string;
+  tiles: Record<string, TileTemplate>;
+};
+
+export type HistoricalStatisticsResponse = {
+  items: HistoricalStatisticItem[];
+};
+
+export type BiasTileSetItem = {
+  layer: string;
+  time_key: string;
+  level_key: string;
+  min_zoom: number;
+  max_zoom: number;
+  formats: string[];
+  tile: TileTemplate;
+};
+
+export type BiasTileSetsResponse = {
+  items: BiasTileSetItem[];
+};
+
+function normalizeApiBaseUrl(apiBaseUrl: string): string {
+  return apiBaseUrl.trim().replace(/\/+$/, '');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function parseTileTemplate(value: unknown): TileTemplate | null {
+  if (!isRecord(value)) return null;
+  const template = value.template;
+  const legend = value.legend;
+  if (!isNonEmptyString(template) || !isNonEmptyString(legend)) return null;
+  return { template: template.trim(), legend: legend.trim() };
+}
+
+function parseHistoricalStatisticItem(value: unknown): HistoricalStatisticItem | null {
+  if (!isRecord(value)) return null;
+
+  const source = value.source;
+  const variable = value.variable;
+  const window_kind = value.window_kind;
+  const window_key = value.window_key;
+  const version = value.version;
+  const window_start = value.window_start;
+  const window_end = value.window_end;
+  const samples = value.samples;
+  const dataset_path = value.dataset_path;
+  const metadata_path = value.metadata_path;
+
+  if (
+    !isNonEmptyString(source) ||
+    !isNonEmptyString(variable) ||
+    !isNonEmptyString(window_kind) ||
+    !isNonEmptyString(window_key) ||
+    !isNonEmptyString(version) ||
+    !isNonEmptyString(window_start) ||
+    !isNonEmptyString(window_end) ||
+    typeof samples !== 'number' ||
+    !Number.isFinite(samples) ||
+    !isNonEmptyString(dataset_path) ||
+    !isNonEmptyString(metadata_path)
+  ) {
+    return null;
+  }
+
+  const tiles: Record<string, TileTemplate> = {};
+  const tilesRaw = value.tiles;
+  if (isRecord(tilesRaw)) {
+    for (const [key, entry] of Object.entries(tilesRaw)) {
+      const parsed = parseTileTemplate(entry);
+      if (!parsed) continue;
+      tiles[key] = parsed;
+    }
+  }
+
+  return {
+    source: source.trim(),
+    variable: variable.trim(),
+    window_kind: window_kind.trim(),
+    window_key: window_key.trim(),
+    version: version.trim(),
+    window_start: window_start.trim(),
+    window_end: window_end.trim(),
+    samples,
+    dataset_path: dataset_path.trim(),
+    metadata_path: metadata_path.trim(),
+    tiles,
+  };
+}
+
+function parseHistoricalStatisticsResponse(payload: unknown): HistoricalStatisticsResponse {
+  if (!isRecord(payload)) return { items: [] };
+  const rawItems = payload.items;
+  if (!Array.isArray(rawItems)) return { items: [] };
+  const items: HistoricalStatisticItem[] = [];
+  for (const entry of rawItems) {
+    const parsed = parseHistoricalStatisticItem(entry);
+    if (!parsed) continue;
+    items.push(parsed);
+  }
+  return { items };
+}
+
+function parseBiasTileSetItem(value: unknown): BiasTileSetItem | null {
+  if (!isRecord(value)) return null;
+  const layer = value.layer;
+  const time_key = value.time_key;
+  const level_key = value.level_key;
+  const min_zoom = value.min_zoom;
+  const max_zoom = value.max_zoom;
+  const formatsRaw = value.formats;
+  const tile = parseTileTemplate(value.tile);
+
+  if (
+    !isNonEmptyString(layer) ||
+    !isNonEmptyString(time_key) ||
+    !isNonEmptyString(level_key) ||
+    typeof min_zoom !== 'number' ||
+    !Number.isFinite(min_zoom) ||
+    typeof max_zoom !== 'number' ||
+    !Number.isFinite(max_zoom) ||
+    !tile
+  ) {
+    return null;
+  }
+
+  const formats = Array.isArray(formatsRaw)
+    ? formatsRaw
+        .filter((fmt) => isNonEmptyString(fmt))
+        .map((fmt) => fmt.trim().toLowerCase())
+        .filter((fmt, index, all) => all.indexOf(fmt) === index)
+    : [];
+
+  return {
+    layer: layer.trim(),
+    time_key: time_key.trim(),
+    level_key: level_key.trim(),
+    min_zoom,
+    max_zoom,
+    formats,
+    tile,
+  };
+}
+
+function parseBiasTileSetsResponse(payload: unknown): BiasTileSetsResponse {
+  if (!isRecord(payload)) return { items: [] };
+  const rawItems = payload.items;
+  if (!Array.isArray(rawItems)) return { items: [] };
+  const items: BiasTileSetItem[] = [];
+  for (const entry of rawItems) {
+    const parsed = parseBiasTileSetItem(entry);
+    if (!parsed) continue;
+    items.push(parsed);
+  }
+  return { items };
+}
+
+type CacheEntry<T> = { value: T; expiresAt: number };
+
+const CACHE_TTL_MS = 60_000;
+const CACHE_MAX_ENTRIES = 20;
+
+const historicalStatisticsCache = new Map<string, CacheEntry<HistoricalStatisticsResponse>>();
+const biasTileSetsCache = new Map<string, CacheEntry<BiasTileSetsResponse>>();
+
+function readCache<T>(cache: Map<string, CacheEntry<T>>, key: string): T | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() >= entry.expiresAt) {
+    cache.delete(key);
+    return undefined;
+  }
+  cache.delete(key);
+  cache.set(key, entry);
+  return entry.value;
+}
+
+function writeCache<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T) {
+  cache.delete(key);
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  while (cache.size > CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value as string | undefined;
+    if (!oldest) break;
+    cache.delete(oldest);
+  }
+}
+
+export function clearAnalyticsCache() {
+  historicalStatisticsCache.clear();
+  biasTileSetsCache.clear();
+}
+
+export async function fetchHistoricalStatistics(options: {
+  apiBaseUrl: string;
+  source?: string;
+  variable?: string;
+  window_kind?: string;
+  version?: string;
+  fmt?: string;
+  limit?: number;
+  offset?: number;
+  signal?: AbortSignal;
+  cache?: 'default' | 'no-cache';
+}): Promise<HistoricalStatisticsResponse> {
+  const base = normalizeApiBaseUrl(options.apiBaseUrl);
+  const url = new URL('/api/v1/analytics/historical/statistics', base);
+  if (isNonEmptyString(options.source)) url.searchParams.set('source', options.source.trim());
+  if (isNonEmptyString(options.variable)) url.searchParams.set('variable', options.variable.trim());
+  if (isNonEmptyString(options.window_kind)) url.searchParams.set('window_kind', options.window_kind.trim());
+  if (isNonEmptyString(options.version)) url.searchParams.set('version', options.version.trim());
+  if (isNonEmptyString(options.fmt)) url.searchParams.set('fmt', options.fmt.trim());
+  if (typeof options.limit === 'number' && Number.isFinite(options.limit)) {
+    url.searchParams.set('limit', String(options.limit));
+  }
+  if (typeof options.offset === 'number' && Number.isFinite(options.offset)) {
+    url.searchParams.set('offset', String(options.offset));
+  }
+
+  const key = url.toString();
+  const cached =
+    options.cache !== 'no-cache' ? readCache(historicalStatisticsCache, key) : undefined;
+  if (cached) return cached;
+
+  try {
+    const payload = await fetchJson<unknown>(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: options.signal,
+      cache: options.cache === 'no-cache' ? 'no-store' : undefined,
+    });
+    const parsed = parseHistoricalStatisticsResponse(payload);
+    writeCache(historicalStatisticsCache, key, parsed);
+    return parsed;
+  } catch (error) {
+    if (isHttpError(error)) {
+      throw new Error(`Failed to load historical statistics: ${error.status}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+export async function fetchBiasTileSets(options: {
+  apiBaseUrl: string;
+  layer?: string;
+  fmt?: string;
+  limit?: number;
+  offset?: number;
+  signal?: AbortSignal;
+  cache?: 'default' | 'no-cache';
+}): Promise<BiasTileSetsResponse> {
+  const base = normalizeApiBaseUrl(options.apiBaseUrl);
+  const url = new URL('/api/v1/analytics/bias/tile-sets', base);
+  if (isNonEmptyString(options.layer)) url.searchParams.set('layer', options.layer.trim());
+  if (isNonEmptyString(options.fmt)) url.searchParams.set('fmt', options.fmt.trim());
+  if (typeof options.limit === 'number' && Number.isFinite(options.limit)) {
+    url.searchParams.set('limit', String(options.limit));
+  }
+  if (typeof options.offset === 'number' && Number.isFinite(options.offset)) {
+    url.searchParams.set('offset', String(options.offset));
+  }
+
+  const key = url.toString();
+  const cached = options.cache !== 'no-cache' ? readCache(biasTileSetsCache, key) : undefined;
+  if (cached) return cached;
+
+  try {
+    const payload = await fetchJson<unknown>(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: options.signal,
+      cache: options.cache === 'no-cache' ? 'no-store' : undefined,
+    });
+    const parsed = parseBiasTileSetsResponse(payload);
+    writeCache(biasTileSetsCache, key, parsed);
+    return parsed;
+  } catch (error) {
+    if (isHttpError(error)) {
+      throw new Error(`Failed to load bias tile sets: ${error.status}`, { cause: error });
+    }
+    throw error;
+  }
+}
+

--- a/apps/web/src/features/layers/AnalyticsTileLayer.test.ts
+++ b/apps/web/src/features/layers/AnalyticsTileLayer.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('cesium', () => {
+  return {
+    GeographicTilingScheme: vi.fn((options?: unknown) => ({ kind: 'geographic', options })),
+    Rectangle: {
+      fromDegrees: vi.fn((west: number, south: number, east: number, north: number) => ({
+        west,
+        south,
+        east,
+        north,
+      })),
+    },
+    UrlTemplateImageryProvider: vi.fn(function (options: unknown) {
+      return { kind: 'url-template', options };
+    }),
+    ImageryLayer: vi.fn(function (provider: unknown, options: unknown) {
+      return { kind: 'imagery-layer', provider, ...(options as Record<string, unknown>) };
+    }),
+    TextureMinificationFilter: { LINEAR: 'linear', NEAREST: 'nearest' },
+    TextureMagnificationFilter: { LINEAR: 'linear', NEAREST: 'nearest' },
+  };
+});
+
+import { GeographicTilingScheme, ImageryLayer, Rectangle, UrlTemplateImageryProvider } from 'cesium';
+import { AnalyticsTileLayer } from './AnalyticsTileLayer';
+
+function makeViewer() {
+  return {
+    imageryLayers: {
+      add: vi.fn(),
+      remove: vi.fn(),
+      raiseToTop: vi.fn(),
+    },
+    scene: {
+      requestRender: vi.fn(),
+    },
+  };
+}
+
+describe('AnalyticsTileLayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates an ImageryLayer backed by a URL template and applies levels/rectangle', () => {
+    const viewer = makeViewer();
+
+    new AnalyticsTileLayer(viewer as never, {
+      id: 'historical',
+      urlTemplate: 'http://api.test/api/v1/tiles/statistics/x/{z}/{x}/{y}.png',
+      frameKey: 'frame-1',
+      opacity: 0.6,
+      visible: true,
+      zIndex: 60,
+      rectangle: { west: 100, south: 20, east: 110, north: 30 },
+      minimumLevel: 8,
+      maximumLevel: 10,
+      credit: 'Test tiles',
+    });
+
+    expect(vi.mocked(GeographicTilingScheme)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(Rectangle.fromDegrees)).toHaveBeenCalledWith(100, 20, 110, 30);
+
+    expect(vi.mocked(UrlTemplateImageryProvider)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining('/api/v1/tiles/statistics/'),
+        minimumLevel: 8,
+        maximumLevel: 10,
+        tileWidth: 256,
+        tileHeight: 256,
+        rectangle: expect.objectContaining({ west: 100, south: 20, east: 110, north: 30 }),
+        credit: 'Test tiles',
+      }),
+    );
+
+    expect(vi.mocked(ImageryLayer)).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'url-template' }),
+      expect.objectContaining({ alpha: 0.6, show: true }),
+    );
+    expect(viewer.imageryLayers.add).toHaveBeenCalledTimes(1);
+    expect(viewer.scene.requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates opacity and visibility without recreating the layer', () => {
+    const viewer = makeViewer();
+
+    const layer = new AnalyticsTileLayer(viewer as never, {
+      id: 'historical',
+      urlTemplate: 'http://api.test/api/v1/tiles/statistics/x/{z}/{x}/{y}.png',
+      frameKey: 'frame-1',
+      opacity: 1,
+      visible: true,
+      zIndex: 60,
+    });
+
+    const imageryLayer = vi.mocked(ImageryLayer).mock.results[0]?.value as {
+      alpha?: number;
+      show?: boolean;
+    };
+
+    viewer.scene.requestRender.mockClear();
+    viewer.imageryLayers.remove.mockClear();
+    vi.mocked(UrlTemplateImageryProvider).mockClear();
+
+    layer.update({
+      id: 'historical',
+      urlTemplate: 'http://api.test/api/v1/tiles/statistics/x/{z}/{x}/{y}.png',
+      frameKey: 'frame-1',
+      opacity: 0.25,
+      visible: false,
+      zIndex: 60,
+    });
+
+    expect(viewer.imageryLayers.remove).not.toHaveBeenCalled();
+    expect(vi.mocked(UrlTemplateImageryProvider)).not.toHaveBeenCalled();
+    expect(imageryLayer.alpha).toBe(0.25);
+    expect(imageryLayer.show).toBe(false);
+    expect(viewer.scene.requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates the layer when the URL template changes', () => {
+    const viewer = makeViewer();
+
+    const layer = new AnalyticsTileLayer(viewer as never, {
+      id: 'historical',
+      urlTemplate: 'http://api.test/api/v1/tiles/statistics/x/{z}/{x}/{y}.png',
+      frameKey: 'frame-1',
+      opacity: 1,
+      visible: true,
+      zIndex: 60,
+    });
+
+    const firstLayer = layer.layer;
+    expect(firstLayer).toBeTruthy();
+
+    layer.update({
+      id: 'historical',
+      urlTemplate: 'http://api.test/api/v1/tiles/statistics/y/{z}/{x}/{y}.png',
+      frameKey: 'frame-1',
+      opacity: 1,
+      visible: true,
+      zIndex: 60,
+    });
+
+    expect(viewer.imageryLayers.remove).toHaveBeenCalledWith(firstLayer, true);
+    expect(viewer.imageryLayers.add).toHaveBeenCalledTimes(2);
+  });
+
+  it('recreates the layer when levels change', () => {
+    const viewer = makeViewer();
+
+    const layer = new AnalyticsTileLayer(viewer as never, {
+      id: 'historical',
+      urlTemplate: 'http://api.test/api/v1/tiles/statistics/x/{z}/{x}/{y}.png',
+      frameKey: 'frame-1',
+      opacity: 1,
+      visible: true,
+      zIndex: 60,
+      minimumLevel: 0,
+      maximumLevel: 6,
+    });
+
+    const firstLayer = layer.layer;
+
+    layer.update({
+      id: 'historical',
+      urlTemplate: 'http://api.test/api/v1/tiles/statistics/x/{z}/{x}/{y}.png',
+      frameKey: 'frame-1',
+      opacity: 1,
+      visible: true,
+      zIndex: 60,
+      minimumLevel: 8,
+      maximumLevel: 10,
+    });
+
+    expect(viewer.imageryLayers.remove).toHaveBeenCalledWith(firstLayer, true);
+    expect(viewer.imageryLayers.add).toHaveBeenCalledTimes(2);
+  });
+
+  it('destroys its Cesium layer and requests render', () => {
+    const viewer = makeViewer();
+
+    const layer = new AnalyticsTileLayer(viewer as never, {
+      id: 'historical',
+      urlTemplate: 'http://api.test/api/v1/tiles/statistics/x/{z}/{x}/{y}.png',
+      frameKey: 'frame-1',
+      opacity: 0.5,
+      visible: true,
+      zIndex: 60,
+    });
+
+    const imageryLayer = layer.layer;
+    expect(imageryLayer).toBeTruthy();
+
+    viewer.scene.requestRender.mockClear();
+
+    layer.destroy();
+
+    expect(viewer.imageryLayers.remove).toHaveBeenCalledWith(imageryLayer, true);
+    expect(viewer.scene.requestRender).toHaveBeenCalledTimes(1);
+    expect(layer.layer).toBeNull();
+  });
+});
+

--- a/apps/web/src/features/layers/AnalyticsTileLayer.ts
+++ b/apps/web/src/features/layers/AnalyticsTileLayer.ts
@@ -1,0 +1,161 @@
+import {
+  GeographicTilingScheme,
+  ImageryLayer,
+  Rectangle,
+  TextureMagnificationFilter,
+  TextureMinificationFilter,
+  UrlTemplateImageryProvider,
+  type Viewer,
+} from 'cesium';
+
+import { attachTileCacheToProvider } from './tilePrefetch';
+import type { RectangleDegrees } from './types';
+
+export type AnalyticsTileLayerParams = {
+  id: string;
+  urlTemplate: string;
+  frameKey: string;
+  opacity: number;
+  visible: boolean;
+  zIndex: number;
+  rectangle?: RectangleDegrees | null;
+  minimumLevel?: number | null;
+  maximumLevel?: number | null;
+  credit?: string;
+};
+
+function clampOpacity(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function normalizeRectangle(value: RectangleDegrees | null | undefined): Rectangle | undefined {
+  if (!value) return undefined;
+  const { west, south, east, north } = value;
+  if (![west, south, east, north].every((item) => Number.isFinite(item))) return undefined;
+  return Rectangle.fromDegrees(west, south, east, north);
+}
+
+function normalizeLevel(value: number | null | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  const rounded = Math.floor(value);
+  if (rounded < 0) return 0;
+  return rounded;
+}
+
+function coverageKey(value: RectangleDegrees | null | undefined): string {
+  if (!value) return 'global';
+  const { west, south, east, north } = value;
+  return `${west},${south},${east},${north}`;
+}
+
+function levelsKey(minimumLevel: number | undefined, maximumLevel: number | undefined): string {
+  return `${minimumLevel ?? ''}:${maximumLevel ?? ''}`;
+}
+
+export class AnalyticsTileLayer {
+  public readonly id: string;
+  private readonly viewer: Viewer;
+  private current: AnalyticsTileLayerParams;
+  private imageryLayer: ImageryLayer | null = null;
+  private urlTemplate: string | null = null;
+  private frameKey: string | null = null;
+  private coverageKey: string | null = null;
+  private levelsKey: string | null = null;
+
+  constructor(viewer: Viewer, params: AnalyticsTileLayerParams) {
+    this.viewer = viewer;
+    this.id = params.id;
+    this.current = params;
+    this.sync({ forceRecreate: true });
+  }
+
+  get layer(): ImageryLayer | null {
+    return this.imageryLayer;
+  }
+
+  get zIndex(): number {
+    return this.current.zIndex;
+  }
+
+  update(params: AnalyticsTileLayerParams): void {
+    if (params.id !== this.id) {
+      throw new Error(`AnalyticsTileLayer id mismatch: ${params.id}`);
+    }
+
+    this.current = params;
+    this.sync();
+  }
+
+  destroy(): void {
+    if (!this.imageryLayer) return;
+    this.viewer.imageryLayers.remove(this.imageryLayer, true);
+    this.imageryLayer = null;
+    this.urlTemplate = null;
+    this.frameKey = null;
+    this.coverageKey = null;
+    this.levelsKey = null;
+    this.viewer.scene.requestRender();
+  }
+
+  private sync(options: { forceRecreate?: boolean } = {}): void {
+    const nextTemplate = this.current.urlTemplate.trim();
+    const nextFrameKey = this.current.frameKey.trim();
+    const nextCoverageKey = coverageKey(this.current.rectangle);
+    const minimumLevel = normalizeLevel(this.current.minimumLevel);
+    const maximumLevel = normalizeLevel(this.current.maximumLevel);
+    const nextLevelsKey = levelsKey(minimumLevel, maximumLevel);
+
+    const shouldRecreate =
+      options.forceRecreate ||
+      this.imageryLayer === null ||
+      this.urlTemplate !== nextTemplate ||
+      this.frameKey !== nextFrameKey ||
+      this.coverageKey !== nextCoverageKey ||
+      this.levelsKey !== nextLevelsKey;
+
+    if (shouldRecreate) {
+      if (this.imageryLayer) {
+        this.viewer.imageryLayers.remove(this.imageryLayer, true);
+      }
+
+      const rectangle = normalizeRectangle(this.current.rectangle);
+
+      const provider = new UrlTemplateImageryProvider({
+        url: nextTemplate,
+        tilingScheme: new GeographicTilingScheme({
+          numberOfLevelZeroTilesX: 1,
+          numberOfLevelZeroTilesY: 1,
+        }),
+        ...(minimumLevel == null ? {} : { minimumLevel }),
+        ...(maximumLevel == null ? {} : { maximumLevel }),
+        tileWidth: 256,
+        tileHeight: 256,
+        rectangle,
+        credit: this.current.credit ?? 'Analytics tiles',
+      });
+      attachTileCacheToProvider(provider, { frameKey: nextFrameKey });
+
+      this.imageryLayer = new ImageryLayer(provider, {
+        alpha: clampOpacity(this.current.opacity),
+        show: this.current.visible,
+      });
+      this.viewer.imageryLayers.add(this.imageryLayer);
+      this.imageryLayer.minificationFilter = TextureMinificationFilter.NEAREST;
+      this.imageryLayer.magnificationFilter = TextureMagnificationFilter.NEAREST;
+      this.urlTemplate = nextTemplate;
+      this.frameKey = nextFrameKey;
+      this.coverageKey = nextCoverageKey;
+      this.levelsKey = nextLevelsKey;
+    }
+
+    if (!this.imageryLayer) return;
+
+    this.imageryLayer.alpha = clampOpacity(this.current.opacity);
+    this.imageryLayer.show = this.current.visible;
+    this.viewer.scene.requestRender();
+  }
+}
+

--- a/apps/web/src/features/viewer/CesiumViewer.test.tsx
+++ b/apps/web/src/features/viewer/CesiumViewer.test.tsx
@@ -240,18 +240,18 @@ vi.mock('cesium', () => {
       }
     },
     screenSpaceEventHandler,
-	    imageryLayers: {
-	      get: vi.fn(() => baseLayer),
-	      remove: vi.fn(),
-	      addImageryProvider: vi.fn(() => baseLayer),
-	      add: vi.fn((layer: unknown) => layer),
-	      raiseToTop: vi.fn(),
-	    },
-	    terrainProvider: { kind: 'base-terrain' },
-	    scene: {
-	      requestRenderMode: false,
-	      maximumRenderTimeChange: 0,
-	      requestRender: vi.fn(),
+    imageryLayers: {
+      get: vi.fn(() => baseLayer),
+      remove: vi.fn(),
+      addImageryProvider: vi.fn(() => baseLayer),
+      add: vi.fn((layer: unknown) => layer),
+      raiseToTop: vi.fn(),
+    },
+    terrainProvider: { kind: 'base-terrain' },
+    scene: {
+      requestRenderMode: false,
+      maximumRenderTimeChange: 0,
+      requestRender: vi.fn(),
       mode: SceneMode.SCENE3D,
       morphComplete,
       morphTo2D: vi.fn(() => {
@@ -260,12 +260,12 @@ vi.mock('cesium', () => {
       morphTo3D: vi.fn(() => {
         viewer.scene.mode = SceneMode.SCENE3D;
       }),
-	      morphToColumbusView: vi.fn(() => {
-	        viewer.scene.mode = SceneMode.COLUMBUS_VIEW;
-	      }),
-	      globe: {
-	        ellipsoid: baseEllipsoid,
-	      },
+      morphToColumbusView: vi.fn(() => {
+        viewer.scene.mode = SceneMode.COLUMBUS_VIEW;
+      }),
+      globe: {
+        ellipsoid: baseEllipsoid,
+      },
       fog: {
         enabled: false,
         density: 0,
@@ -363,10 +363,10 @@ vi.mock('cesium', () => {
     UrlTemplateImageryProvider: vi.fn(function (options: unknown) {
       return { kind: 'url-template', options };
     }),
-	    WebMercatorTilingScheme: vi.fn(),
-	    GeographicTilingScheme,
-	    TextureMinificationFilter,
-	    TextureMagnificationFilter,
+    WebMercatorTilingScheme: vi.fn(),
+    GeographicTilingScheme,
+    TextureMinificationFilter,
+    TextureMagnificationFilter,
     Math: {
       toDegrees: vi.fn((radians: number) => radians),
       PI_OVER_TWO: Math.PI / 2
@@ -383,12 +383,12 @@ vi.mock('cesium', () => {
       triggerLeftDoubleClick: (movement: { position?: unknown }) => {
         leftDoubleClickHandler?.(movement);
       },
-	    },
-	    createWorldTerrainAsync,
-	    Ellipsoid,
-	    EllipsoidTerrainProvider,
-	    Ion,
-	  };
+    },
+    createWorldTerrainAsync,
+    Ellipsoid,
+    EllipsoidTerrainProvider,
+    Ion,
+  };
 });
 
 import { Cartesian3, EllipsoidTerrainProvider, Rectangle, createWorldTerrainAsync, Viewer } from 'cesium';
@@ -1890,14 +1890,14 @@ describe('CesiumViewer', () => {
         if (url.startsWith('http://api.test/api/v1/vectors/')) {
           if (url.includes('bbox=10,20,30,40')) {
             return Promise.resolve(jsonResponse({ vectors: vectorsA }));
-	          }
-	          if (url.includes('bbox=1,2,3,4')) {
-	            secondSignal = init?.signal ?? undefined;
-	            if (secondSignal) {
-	              secondAborted = secondSignal.aborted;
-	              secondSignal.addEventListener('abort', () => {
-	                secondAborted = true;
-	              });
+          }
+          if (url.includes('bbox=1,2,3,4')) {
+            secondSignal = init?.signal ?? undefined;
+            if (secondSignal) {
+              secondAborted = secondSignal.aborted;
+              secondSignal.addEventListener('abort', () => {
+                secondAborted = true;
+              });
             }
             return new Promise((resolve) => {
               resolveSecondFetch = resolve;
@@ -3141,6 +3141,13 @@ describe('CesiumViewer', () => {
           });
         }
         if (url.startsWith('http://api.test/api/v1/analytics/historical/statistics')) {
+          const parsed = new URL(url);
+          expect(parsed.searchParams.get('source')).toBe('cldas');
+          expect(parsed.searchParams.get('variable')).toBe('SNOWFALL');
+          expect(parsed.searchParams.get('window_kind')).toBe('rolling_days');
+          expect(parsed.searchParams.get('limit')).toBe('25');
+          expect(parsed.searchParams.get('fmt')).toBe('png');
+
           return jsonResponse({
             schema_version: 1,
             generated_at: '2026-01-01T01:00:00Z',
@@ -3199,14 +3206,14 @@ describe('CesiumViewer', () => {
     });
 
     await waitFor(() => {
-	      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
-	        provider?: { options?: { url?: string; rectangle?: unknown } };
-	      });
-	      const snow = layersAdded.find((layer: {
-	        provider?: { options?: { url?: string; rectangle?: unknown } };
-	      }) => (layer.provider?.options?.url ?? '').includes('/SNOD/'));
-	      expect(snow).toBeTruthy();
-	    });
+      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
+        provider?: { options?: { url?: string; rectangle?: unknown } };
+      });
+      const snow = layersAdded.find((layer: {
+        provider?: { options?: { url?: string; rectangle?: unknown } };
+      }) => (layer.provider?.options?.url ?? '').includes('/SNOD/'));
+      expect(snow).toBeTruthy();
+    });
 
     viewer.imageryLayers.add.mockClear();
 
@@ -3215,14 +3222,18 @@ describe('CesiumViewer', () => {
     });
 
     await waitFor(() => {
-	      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
-	        provider?: { options?: { url?: string } };
-	      });
-	      const history = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
-	        (layer.provider?.options?.url ?? '').includes('/api/v1/tiles/statistics/'),
-	      );
-	      expect(history?.provider?.options?.url).toContain('/snowfall/');
-	    });
+      expect(useLayerManagerStore.getState().getVisibleLayers()).toHaveLength(0);
+    });
+
+    await waitFor(() => {
+      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
+        provider?: { options?: { url?: string } };
+      });
+      const history = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
+        (layer.provider?.options?.url ?? '').includes('/api/v1/tiles/statistics/'),
+      );
+      expect(history?.provider?.options?.url).toContain('/snowfall/');
+    });
   });
 
   it('switches to the bias layer in event mode', async () => {
@@ -3269,6 +3280,11 @@ describe('CesiumViewer', () => {
           });
         }
         if (url.startsWith('http://api.test/api/v1/analytics/bias/tile-sets')) {
+          const parsed = new URL(url);
+          expect(parsed.searchParams.get('layer')).toBeNull();
+          expect(parsed.searchParams.get('limit')).toBe('25');
+          expect(parsed.searchParams.get('fmt')).toBe('png');
+
           return jsonResponse({
             schema_version: 1,
             generated_at: '2026-01-01T01:00:00Z',
@@ -3320,14 +3336,14 @@ describe('CesiumViewer', () => {
     });
 
     await waitFor(() => {
-	      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
-	        provider?: { options?: { url?: string } };
-	      });
-	      const snow = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
-	        (layer.provider?.options?.url ?? '').includes('/SNOD/'),
-	      );
-	      expect(snow).toBeTruthy();
-	    });
+      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
+        provider?: { options?: { url?: string } };
+      });
+      const snow = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
+        (layer.provider?.options?.url ?? '').includes('/SNOD/'),
+      );
+      expect(snow).toBeTruthy();
+    });
 
     viewer.imageryLayers.add.mockClear();
 
@@ -3336,14 +3352,76 @@ describe('CesiumViewer', () => {
     });
 
     await waitFor(() => {
-	      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
-	        provider?: { options?: { url?: string } };
-	      });
-	      const bias = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
-	        (layer.provider?.options?.url ?? '').includes('/api/v1/tiles/bias/temp/'),
-	      );
-	      expect(bias?.provider?.options?.url).toContain('/20260101T000000Z/sfc/');
-	    });
+      expect(useLayerManagerStore.getState().getVisibleLayers()).toHaveLength(0);
+    });
+
+    await waitFor(() => {
+      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
+        provider?: { options?: { url?: string } };
+      });
+      const bias = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
+        (layer.provider?.options?.url ?? '').includes('/api/v1/tiles/bias/temp/'),
+      );
+      expect(bias?.provider?.options?.url).toContain('/20260101T000000Z/sfc/');
+    });
+  });
+
+  it('enforces mutual exclusion between monitoring and analytics layers', async () => {
+    useLayerManagerStore.setState({
+      layers: [
+        {
+          id: 'snow-depth',
+          type: 'snow-depth',
+          variable: 'SNOD',
+          opacity: 0.8,
+          visible: false,
+          zIndex: 50,
+        },
+      ],
+    });
+
+    render(<CesiumViewer />);
+    await waitFor(() => expect(vi.mocked(Viewer)).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useViewModeStore.getState().enterEvent({ productId: '1' });
+    });
+
+    await waitFor(() => {
+      expect(useLayerManagerStore.getState().getVisibleLayers().map((layer) => layer.id)).toEqual(['snow-depth']);
+    });
+
+    act(() => {
+      useEventLayersStore.getState().setMode('history');
+    });
+
+    await waitFor(() => {
+      expect(useLayerManagerStore.getState().getVisibleLayers()).toHaveLength(0);
+    });
+
+    act(() => {
+      useEventLayersStore.getState().setMode('monitoring');
+    });
+
+    await waitFor(() => {
+      expect(useLayerManagerStore.getState().getVisibleLayers().map((layer) => layer.id)).toEqual(['snow-depth']);
+    });
+
+    act(() => {
+      useEventLayersStore.getState().setEnabled(false);
+    });
+
+    await waitFor(() => {
+      expect(useLayerManagerStore.getState().getVisibleLayers()).toHaveLength(0);
+    });
+
+    act(() => {
+      useEventLayersStore.getState().setEnabled(true);
+    });
+
+    await waitFor(() => {
+      expect(useLayerManagerStore.getState().getVisibleLayers().map((layer) => layer.id)).toEqual(['snow-depth']);
+    });
   });
 
   it('shows a monitoring notice when snow depth tiles are missing', async () => {

--- a/apps/web/src/features/viewer/CesiumViewer.test.tsx
+++ b/apps/web/src/features/viewer/CesiumViewer.test.tsx
@@ -3199,12 +3199,14 @@ describe('CesiumViewer', () => {
     });
 
     await waitFor(() => {
-      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
-        provider?: { options?: { url?: string; rectangle?: unknown } };
-      });
-      const snow = layersAdded.find((layer) => (layer.provider?.options?.url ?? '').includes('/SNOD/'));
-      expect(snow).toBeTruthy();
-    });
+	      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
+	        provider?: { options?: { url?: string; rectangle?: unknown } };
+	      });
+	      const snow = layersAdded.find((layer: {
+	        provider?: { options?: { url?: string; rectangle?: unknown } };
+	      }) => (layer.provider?.options?.url ?? '').includes('/SNOD/'));
+	      expect(snow).toBeTruthy();
+	    });
 
     viewer.imageryLayers.add.mockClear();
 
@@ -3213,14 +3215,14 @@ describe('CesiumViewer', () => {
     });
 
     await waitFor(() => {
-      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
-        provider?: { options?: { url?: string } };
-      });
-      const history = layersAdded.find((layer) =>
-        (layer.provider?.options?.url ?? '').includes('/api/v1/tiles/statistics/'),
-      );
-      expect(history?.provider?.options?.url).toContain('/snowfall/');
-    });
+	      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
+	        provider?: { options?: { url?: string } };
+	      });
+	      const history = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
+	        (layer.provider?.options?.url ?? '').includes('/api/v1/tiles/statistics/'),
+	      );
+	      expect(history?.provider?.options?.url).toContain('/snowfall/');
+	    });
   });
 
   it('switches to the bias layer in event mode', async () => {
@@ -3318,12 +3320,14 @@ describe('CesiumViewer', () => {
     });
 
     await waitFor(() => {
-      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
-        provider?: { options?: { url?: string } };
-      });
-      const snow = layersAdded.find((layer) => (layer.provider?.options?.url ?? '').includes('/SNOD/'));
-      expect(snow).toBeTruthy();
-    });
+	      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
+	        provider?: { options?: { url?: string } };
+	      });
+	      const snow = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
+	        (layer.provider?.options?.url ?? '').includes('/SNOD/'),
+	      );
+	      expect(snow).toBeTruthy();
+	    });
 
     viewer.imageryLayers.add.mockClear();
 
@@ -3332,14 +3336,14 @@ describe('CesiumViewer', () => {
     });
 
     await waitFor(() => {
-      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
-        provider?: { options?: { url?: string } };
-      });
-      const bias = layersAdded.find((layer) =>
-        (layer.provider?.options?.url ?? '').includes('/api/v1/tiles/bias/temp/'),
-      );
-      expect(bias?.provider?.options?.url).toContain('/20260101T000000Z/sfc/');
-    });
+	      const layersAdded = viewer.imageryLayers.add.mock.calls.map(([layer]: [unknown]) => layer as {
+	        provider?: { options?: { url?: string } };
+	      });
+	      const bias = layersAdded.find((layer: { provider?: { options?: { url?: string } } }) =>
+	        (layer.provider?.options?.url ?? '').includes('/api/v1/tiles/bias/temp/'),
+	      );
+	      expect(bias?.provider?.options?.url).toContain('/20260101T000000Z/sfc/');
+	    });
   });
 
   it('shows a monitoring notice when snow depth tiles are missing', async () => {

--- a/apps/web/src/features/viewer/EventLayersToggle.test.tsx
+++ b/apps/web/src/features/viewer/EventLayersToggle.test.tsx
@@ -7,27 +7,28 @@ import { EventLayersToggle } from './EventLayersToggle';
 
 beforeEach(() => {
   localStorage.removeItem('digital-earth.eventLayers');
-  useEventLayersStore.setState({ enabled: false, mode: DEFAULT_EVENT_LAYER_MODE });
+  useEventLayersStore.setState({ enabled: true, mode: DEFAULT_EVENT_LAYER_MODE });
 });
 
 test('toggles event layers UI and persists selection', async () => {
   const user = userEvent.setup();
   render(<EventLayersToggle />);
 
-  expect(screen.getByText('默认隐藏，避免信息过载。')).toBeInTheDocument();
-
   const switchInput = screen.getByRole('checkbox', { name: '显示事件图层' });
-  expect(switchInput).not.toBeChecked();
-
-  await user.click(switchInput);
   expect(switchInput).toBeChecked();
+
+  const monitoringButton = screen.getByRole('button', { name: '监测' });
+  expect(monitoringButton).toHaveAttribute('aria-pressed', 'true');
 
   const diffButton = screen.getByRole('button', { name: '差值' });
   await user.click(diffButton);
   expect(diffButton).toHaveAttribute('aria-pressed', 'true');
 
+  await user.click(switchInput);
+  expect(switchInput).not.toBeChecked();
+  expect(screen.getByText('关闭后隐藏，避免信息过载。')).toBeInTheDocument();
+
   const stored = localStorage.getItem('digital-earth.eventLayers');
-  expect(stored).toMatch(/"enabled":true/);
+  expect(stored).toMatch(/"enabled":false/);
   expect(stored).toMatch(/"mode":"difference"/);
 });
-

--- a/apps/web/src/features/viewer/EventLayersToggle.test.tsx
+++ b/apps/web/src/features/viewer/EventLayersToggle.test.tsx
@@ -17,12 +17,14 @@ test('toggles event layers UI and persists selection', async () => {
   const switchInput = screen.getByRole('checkbox', { name: '显示事件图层' });
   expect(switchInput).toBeChecked();
 
-  const monitoringButton = screen.getByRole('button', { name: '监测' });
-  expect(monitoringButton).toHaveAttribute('aria-pressed', 'true');
+  expect(screen.getByRole('radiogroup', { name: '事件图层切换' })).toBeInTheDocument();
 
-  const diffButton = screen.getByRole('button', { name: '差值' });
+  const monitoringButton = screen.getByRole('radio', { name: '监测' });
+  expect(monitoringButton).toHaveAttribute('aria-checked', 'true');
+
+  const diffButton = screen.getByRole('radio', { name: '差值' });
   await user.click(diffButton);
-  expect(diffButton).toHaveAttribute('aria-pressed', 'true');
+  expect(diffButton).toHaveAttribute('aria-checked', 'true');
 
   await user.click(switchInput);
   expect(switchInput).not.toBeChecked();
@@ -31,4 +33,11 @@ test('toggles event layers UI and persists selection', async () => {
   const stored = localStorage.getItem('digital-earth.eventLayers');
   expect(stored).toMatch(/"enabled":false/);
   expect(stored).toMatch(/"mode":"difference"/);
+});
+
+test('shows loading and unavailable indicators', () => {
+  render(<EventLayersToggle historyStatus="loading" differenceStatus="error" />);
+
+  expect(screen.getByRole('radio', { name: /历史.*加载中/ })).toBeInTheDocument();
+  expect(screen.getByRole('radio', { name: /差值.*不可用/ })).toBeInTheDocument();
 });

--- a/apps/web/src/features/viewer/EventLayersToggle.tsx
+++ b/apps/web/src/features/viewer/EventLayersToggle.tsx
@@ -43,9 +43,8 @@ export function EventLayersToggle() {
           ))}
         </div>
       ) : (
-        <div className="eventLayersHelp">默认隐藏，避免信息过载。</div>
+        <div className="eventLayersHelp">关闭后隐藏，避免信息过载。</div>
       )}
     </div>
   );
 }
-

--- a/apps/web/src/features/viewer/EventLayersToggle.tsx
+++ b/apps/web/src/features/viewer/EventLayersToggle.tsx
@@ -1,16 +1,37 @@
 import { useEventLayersStore, type EventLayerMode } from '../../state/eventLayers';
 
+export type EventLayerModeStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
 const MODE_OPTIONS: Array<{ id: EventLayerMode; label: string }> = [
   { id: 'monitoring', label: '监测' },
   { id: 'history', label: '历史' },
   { id: 'difference', label: '差值' },
 ];
 
-export function EventLayersToggle() {
+export type EventLayersToggleProps = {
+  historyStatus?: EventLayerModeStatus;
+  differenceStatus?: EventLayerModeStatus;
+};
+
+function statusLabel(status: EventLayerModeStatus): string | null {
+  if (status === 'loading') return '加载中';
+  if (status === 'error') return '不可用';
+  return null;
+}
+
+export function EventLayersToggle({
+  historyStatus = 'idle',
+  differenceStatus = 'idle',
+}: EventLayersToggleProps) {
   const enabled = useEventLayersStore((state) => state.enabled);
   const setEnabled = useEventLayersStore((state) => state.setEnabled);
   const mode = useEventLayersStore((state) => state.mode);
   const setMode = useEventLayersStore((state) => state.setMode);
+
+  const statusByMode: Partial<Record<EventLayerMode, EventLayerModeStatus>> = {
+    history: historyStatus,
+    difference: differenceStatus,
+  };
 
   return (
     <div className="eventLayersPanel">
@@ -28,19 +49,26 @@ export function EventLayersToggle() {
       </div>
 
       {enabled ? (
-        <div className="eventLayersGroup" role="group" aria-label="事件图层切换">
-          {MODE_OPTIONS.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              className="eventLayersButton"
-              aria-pressed={option.id === mode}
-              data-active={option.id === mode ? 'true' : 'false'}
-              onClick={() => setMode(option.id)}
-            >
-              {option.label}
-            </button>
-          ))}
+        <div className="eventLayersGroup" role="radiogroup" aria-label="事件图层切换">
+          {MODE_OPTIONS.map((option) => {
+            const status = statusByMode[option.id] ?? 'idle';
+            const label = statusLabel(status);
+
+            return (
+              <button
+                key={option.id}
+                type="button"
+                className="eventLayersButton"
+                role="radio"
+                aria-checked={option.id === mode}
+                data-active={option.id === mode ? 'true' : 'false'}
+                onClick={() => setMode(option.id)}
+              >
+                {option.label}
+                {label ? <span className="eventLayersButtonStatus">（{label}）</span> : null}
+              </button>
+            );
+          })}
         </div>
       ) : (
         <div className="eventLayersHelp">关闭后隐藏，避免信息过载。</div>

--- a/apps/web/src/state/eventLayers.ts
+++ b/apps/web/src/state/eventLayers.ts
@@ -49,7 +49,7 @@ function safeWritePersisted(next: { enabled: boolean; mode: EventLayerMode }) {
 
 const persisted = safeReadPersisted();
 
-let enabled = persisted.enabled === true;
+let enabled = typeof persisted.enabled === 'boolean' ? persisted.enabled : true;
 let mode: EventLayerMode = isEventLayerMode(persisted.mode)
   ? persisted.mode
   : DEFAULT_EVENT_LAYER_MODE;
@@ -118,4 +118,3 @@ export const useEventLayersStore: StoreHook = Object.assign(useEventLayersStoreI
   getState,
   setState,
 });
-


### PR DESCRIPTION
## Summary
在事件模式中实现监测/历史/差值图层切换功能

## Changes
- 创建 EventLayersToggle 组件（仅在 Event mode 显示）
- 三种图层模式：监测(默认)、历史、差值(Bias)
- 用户选择持久化到 localStorage
- 集成 Epic #13 的 analytics API
- AbortController 防止竞态条件
- 事件 bbox 裁剪优化性能
- 完整单元测试覆盖 (>= 90%)

## Layer Rules
- 默认：监测层启用，历史/差值隐藏
- 切换互斥：同时只显示一种图层
- 记忆用户选择

## API Integration
- GET /api/v1/analytics/historical/statistics
- GET /api/v1/analytics/bias/tile-sets

## Test Plan
- [x] 图层切换测试
- [x] API 调用测试
- [x] 状态持久化测试
- [x] 错误处理测试
- [x] 测试覆盖率 >= 90%
- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过

## Related Issues
Closes #91