### PR TITLE
[ST-0065] 产品缓存与 ETag 支持 (#96)

### DIFF
--- a/apps/api/src/routers/products.py
+++ b/apps/api/src/routers/products.py
@@ -35,6 +35,9 @@ CACHE_COOLDOWN_TTL_SECONDS: tuple[int, int] = (5, 30)
 PRODUCTS_LIST_CACHE_EPOCH_KEY = "products:list:epoch"
 PRODUCTS_LIST_CACHE_EPOCH_TTL_SECONDS = 60 * 60 * 24
 
+PRODUCT_DETAIL_CACHE_EPOCH_KEY_PREFIX = "products:detail:epoch"
+PRODUCT_DETAIL_CACHE_EPOCH_TTL_SECONDS = 60 * 60 * 24
+
 
 def _normalize_time(value: datetime) -> datetime:
     parsed = value
@@ -125,6 +128,55 @@ async def _bump_products_list_cache_epoch(redis: RedisLike | None) -> None:
         )
     except Exception:  # noqa: BLE001
         logger.warning("products_cache_epoch_bump_failed")
+
+
+def _product_detail_cache_epoch_key(product_id: int) -> str:
+    return f"{PRODUCT_DETAIL_CACHE_EPOCH_KEY_PREFIX}:{int(product_id)}"
+
+
+async def _get_product_detail_cache_epoch(redis: RedisLike, product_id: int) -> str:
+    key = _product_detail_cache_epoch_key(product_id)
+    try:
+        cached = await redis.get(key)
+    except Exception:  # noqa: BLE001
+        return "0"
+
+    if cached:
+        decoded = cached.decode("utf-8", errors="ignore").strip()
+        return decoded or "0"
+
+    token = uuid.uuid4().hex
+    try:
+        await redis.set(
+            key,
+            token.encode("utf-8"),
+            ex=PRODUCT_DETAIL_CACHE_EPOCH_TTL_SECONDS,
+        )
+    except Exception:  # noqa: BLE001
+        return token
+
+    return token
+
+
+async def _bump_product_detail_cache_epoch(
+    redis: RedisLike | None, product_id: int
+) -> None:
+    if redis is None:
+        return
+
+    token = uuid.uuid4().hex
+    key = _product_detail_cache_epoch_key(product_id)
+    try:
+        await redis.set(
+            key,
+            token.encode("utf-8"),
+            ex=PRODUCT_DETAIL_CACHE_EPOCH_TTL_SECONDS,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "product_detail_cache_epoch_bump_failed",
+            extra={"product_id": int(product_id)},
+        )
 
 
 def _parse_bbox(value: Optional[str]) -> Optional[tuple[float, float, float, float]]:
@@ -472,6 +524,24 @@ def _query_product_summaries(
     )
 
 
+def _query_product_detail(product_id: int) -> ProductDetailResponse:
+    try:
+        with Session(db.get_engine()) as session:
+            product = session.execute(
+                select(Product)
+                .options(selectinload(Product.hazards))
+                .where(Product.id == product_id)
+            ).scalar_one_or_none()
+            if product is None:
+                raise HTTPException(status_code=404, detail="Product not found")
+            return _product_detail_response(product)
+    except HTTPException:
+        raise
+    except SQLAlchemyError as exc:
+        logger.error("products_db_error", extra={"error": str(exc)})
+        raise HTTPException(status_code=500, detail="Internal Server Error") from exc
+
+
 @router.get("", response_model=ProductsQueryResponse)
 async def list_products(
     request: Request,
@@ -697,6 +767,7 @@ async def create_product(
         raise HTTPException(status_code=500, detail="Internal Server Error") from exc
 
     await _bump_products_list_cache_epoch(redis)
+    await _bump_product_detail_cache_epoch(redis, response.id)
     return response
 
 
@@ -774,6 +845,7 @@ async def update_product(
         raise HTTPException(status_code=500, detail="Internal Server Error") from exc
 
     await _bump_products_list_cache_epoch(redis)
+    await _bump_product_detail_cache_epoch(redis, product_id)
     return response
 
 
@@ -823,26 +895,62 @@ async def publish_product(
         raise HTTPException(status_code=500, detail="Internal Server Error") from exc
 
     await _bump_products_list_cache_epoch(redis)
+    await _bump_product_detail_cache_epoch(redis, product_id)
     return response
 
 
 @router.get("/{product_id}", response_model=ProductDetailResponse)
-def get_product(product_id: int) -> ProductDetailResponse:
-    try:
-        with Session(db.get_engine()) as session:
-            product = session.execute(
-                select(Product)
-                .options(selectinload(Product.hazards))
-                .where(Product.id == product_id)
-            ).scalar_one_or_none()
-            if product is None:
-                raise HTTPException(status_code=404, detail="Product not found")
-            return _product_detail_response(product)
-    except HTTPException:
-        raise
-    except SQLAlchemyError as exc:
-        logger.error("products_db_error", extra={"error": str(exc)})
-        raise HTTPException(status_code=500, detail="Internal Server Error") from exc
+async def get_product(request: Request, product_id: int) -> Response:
+    redis: RedisLike | None = getattr(request.app.state, "redis_client", None)
+
+    async def _compute() -> bytes:
+        def _sync() -> bytes:
+            payload = _query_product_detail(product_id)
+            return payload.model_dump_json().encode("utf-8")
+
+        return await to_thread(_sync)
+
+    if redis is None:
+        body = await _compute()
+    else:
+        epoch = await _get_product_detail_cache_epoch(redis, product_id)
+        identity = f"epoch={epoch}:product={int(product_id)}"
+
+        fresh_key = f"products:detail:fresh:{identity}"
+        stale_key = f"products:detail:stale:{identity}"
+        lock_key = f"products:detail:lock:{identity}"
+
+        try:
+            result = await get_or_compute_cached_bytes(
+                redis,
+                fresh_key=fresh_key,
+                stale_key=stale_key,
+                lock_key=lock_key,
+                fresh_ttl_seconds=CACHE_FRESH_TTL_SECONDS,
+                stale_ttl_seconds=CACHE_STALE_TTL_SECONDS,
+                lock_ttl_ms=CACHE_LOCK_TTL_MS,
+                wait_timeout_ms=CACHE_WAIT_TIMEOUT_MS,
+                compute=_compute,
+                cooldown_ttl_seconds=CACHE_COOLDOWN_TTL_SECONDS,
+            )
+            body = result.body
+        except TimeoutError as exc:
+            raise HTTPException(
+                status_code=503, detail="Product cache warming timed out"
+            ) from exc
+        except HTTPException:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("product_cache_unavailable", extra={"error": str(exc)})
+            body = await _compute()
+
+    etag = f'"sha256-{hashlib.sha256(body).hexdigest()}"'
+    headers = {"Cache-Control": CACHE_CONTROL_HEADER, "ETag": etag}
+
+    if if_none_match_matches(request.headers.get("if-none-match"), etag):
+        return Response(status_code=304, headers=headers)
+
+    return Response(content=body, media_type="application/json", headers=headers)
 
 
 @router.get("/{product_id}/versions", response_model=ProductVersionsResponse)

--- a/apps/api/src/routers/products.py
+++ b/apps/api/src/routers/products.py
@@ -76,7 +76,9 @@ def _pack_cached_http_response(*, body: bytes, etag: str, cache_control: str) ->
     )
 
 
-def _unpack_cached_http_response(payload: bytes) -> tuple[bytes, str | None, str | None]:
+def _unpack_cached_http_response(
+    payload: bytes,
+) -> tuple[bytes, str | None, str | None]:
     if not payload.startswith(b'"sha256-'):
         return payload, None, None
 

--- a/apps/api/tests/test_products_api.py
+++ b/apps/api/tests/test_products_api.py
@@ -431,11 +431,15 @@ def test_product_detail_endpoint_etag_returns_304_on_match(
     etag = response.headers.get("etag")
     assert etag
 
-    cached = client.get(f"/api/v1/products/{product_id}", headers={"if-none-match": etag})
+    cached = client.get(
+        f"/api/v1/products/{product_id}", headers={"if-none-match": etag}
+    )
     assert cached.status_code == 304
 
 
-def test_products_snapshot_helpers_support_non_utc_isoformat_and_memoryview_geometry() -> None:
+def test_products_snapshot_helpers_support_non_utc_isoformat_and_memoryview_geometry() -> (
+    None
+):
     from routers import products as products_router
 
     dt = datetime(2026, 1, 1, tzinfo=timezone(timedelta(hours=9)))
@@ -448,7 +452,9 @@ def test_products_snapshot_helpers_support_non_utc_isoformat_and_memoryview_geom
 
 
 @pytest.mark.anyio
-async def test_products_cache_epoch_helpers_return_defaults_when_redis_unavailable() -> None:
+async def test_products_cache_epoch_helpers_return_defaults_when_redis_unavailable() -> (
+    None
+):
     from routers import products as products_router
 
     class _BoomRedis:
@@ -459,7 +465,9 @@ async def test_products_cache_epoch_helpers_return_defaults_when_redis_unavailab
             raise RuntimeError("boom")
 
     assert await products_router._get_products_list_cache_epoch(_BoomRedis()) == "0"
-    assert await products_router._get_product_detail_cache_epoch(_BoomRedis(), 123) == "0"
+    assert (
+        await products_router._get_product_detail_cache_epoch(_BoomRedis(), 123) == "0"
+    )
     await products_router._bump_products_list_cache_epoch(None)
     await products_router._bump_product_detail_cache_epoch(None, 123)
 
@@ -480,7 +488,9 @@ def test_product_detail_cache_is_invalidated_on_update(
     assert cached.json()["text"] == "seeded 降雪"
     assert cached.json()["status"] == "published"
 
-    updated = client.put(f"/api/v1/products/{product_id}", json={"text": "updated text"})
+    updated = client.put(
+        f"/api/v1/products/{product_id}", json={"text": "updated text"}
+    )
     assert updated.status_code == 200
     assert updated.json()["text"] == "updated text"
     assert updated.json()["status"] == "draft"


### PR DESCRIPTION
## Summary
为产品 API 添加 Redis 缓存和 ETag 支持

## Changes
- 产品详情 API 添加 Redis 缓存
- 基于响应内容 SHA256 生成 ETag
- 支持 If-None-Match 请求头，命中返回 304 Not Modified
- 按产品维度的缓存 epoch key
- 创建/更新/发布产品时自动失效缓存
- 完整单元测试覆盖 (>= 90%)

## Caching Strategy
- 详情缓存：基于 product_id + epoch
- ETag：基于响应内容 SHA256 哈希
- 失效：发布新版本时 bump epoch

## Test Plan
- [x] 详情缓存命中测试
- [x] ETag 304 响应测试
- [x] 更新/发布后缓存失效测试
- [x] Epoch 异常兜底测试
- [x] 测试覆盖率 >= 90%
- [x] Python lint 检查通过

## Related Issues
Closes #96