### PR TITLE
[ST-0014] 加载 OSM 3D Buildings（ion）

### DIFF
--- a/apps/web/src/features/layout/InfoPanel.tsx
+++ b/apps/web/src/features/layout/InfoPanel.tsx
@@ -5,6 +5,7 @@ import { useViewerStatsStore } from '../../state/viewerStats';
 import { useViewModeStore } from '../../state/viewMode';
 import { EventListPanel } from '../products/EventListPanel';
 import PerformanceModeToggle from '../settings/PerformanceModeToggle';
+import OsmBuildingsToggle from '../settings/OsmBuildingsToggle';
 
 export type InfoPanelProps = {
   collapsed: boolean;
@@ -174,6 +175,7 @@ export function InfoPanel({ collapsed, onToggleCollapsed }: InfoPanelProps) {
                       FPS: {fps != null ? `${fps}` : 'N/A'}
                     </div>
                   </div>
+                  <OsmBuildingsToggle />
                   <div className="text-xs text-slate-400">
                     Low 模式会减少粒子与风矢密度，并关闭体云/建筑（如有），以提升低性能设备体验。
                   </div>

--- a/apps/web/src/features/settings/OsmBuildingsToggle.test.tsx
+++ b/apps/web/src/features/settings/OsmBuildingsToggle.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, expect, test } from 'vitest';
+
+import { usePerformanceModeStore } from '../../state/performanceMode';
+import { useOsmBuildingsStore } from '../../state/osmBuildings';
+import OsmBuildingsToggle from './OsmBuildingsToggle';
+
+beforeEach(() => {
+  localStorage.removeItem('digital-earth.performanceMode');
+  localStorage.removeItem('digital-earth.osmBuildings');
+  usePerformanceModeStore.setState({ mode: 'high' });
+  useOsmBuildingsStore.setState({ enabled: true });
+});
+
+test('toggles OSM buildings and persists', () => {
+  render(<OsmBuildingsToggle />);
+
+  const checkbox = screen.getByRole('checkbox', { name: '开启' });
+  expect(checkbox).toBeChecked();
+
+  fireEvent.click(checkbox);
+  expect(useOsmBuildingsStore.getState().enabled).toBe(false);
+
+  const stored = localStorage.getItem('digital-earth.osmBuildings');
+  expect(stored).toMatch(/"enabled":false/);
+});
+
+test('disables OSM buildings toggle in low performance mode', () => {
+  usePerformanceModeStore.setState({ mode: 'low' });
+  useOsmBuildingsStore.setState({ enabled: true });
+
+  render(<OsmBuildingsToggle />);
+
+  const checkbox = screen.getByRole('checkbox', { name: 'Low 模式已关闭' });
+  expect(checkbox).toBeDisabled();
+  expect(checkbox).not.toBeChecked();
+});
+

--- a/apps/web/src/features/settings/OsmBuildingsToggle.test.tsx
+++ b/apps/web/src/features/settings/OsmBuildingsToggle.test.tsx
@@ -15,8 +15,12 @@ beforeEach(() => {
 test('toggles OSM buildings and persists', () => {
   render(<OsmBuildingsToggle />);
 
-  const checkbox = screen.getByRole('checkbox', { name: '开启' });
+  const checkbox = screen.getByRole('checkbox', { name: '3D 建筑' });
   expect(checkbox).toBeChecked();
+
+  const statusId = checkbox.getAttribute('aria-describedby');
+  expect(statusId).toBeTruthy();
+  expect(document.getElementById(statusId!)).toHaveTextContent('开启');
 
   fireEvent.click(checkbox);
   expect(useOsmBuildingsStore.getState().enabled).toBe(false);
@@ -31,8 +35,11 @@ test('disables OSM buildings toggle in low performance mode', () => {
 
   render(<OsmBuildingsToggle />);
 
-  const checkbox = screen.getByRole('checkbox', { name: 'Low 模式已关闭' });
+  const checkbox = screen.getByRole('checkbox', { name: '3D 建筑' });
   expect(checkbox).toBeDisabled();
   expect(checkbox).not.toBeChecked();
-});
 
+  const statusId = checkbox.getAttribute('aria-describedby');
+  expect(statusId).toBeTruthy();
+  expect(document.getElementById(statusId!)).toHaveTextContent('Low 模式已关闭');
+});

--- a/apps/web/src/features/settings/OsmBuildingsToggle.tsx
+++ b/apps/web/src/features/settings/OsmBuildingsToggle.tsx
@@ -1,0 +1,31 @@
+import { usePerformanceModeStore } from '../../state/performanceMode';
+import { useOsmBuildingsStore } from '../../state/osmBuildings';
+
+export default function OsmBuildingsToggle() {
+  const performanceMode = usePerformanceModeStore((state) => state.mode);
+  const lowModeEnabled = performanceMode === 'low';
+
+  const enabled = useOsmBuildingsStore((state) => state.enabled);
+  const setEnabled = useOsmBuildingsStore((state) => state.setEnabled);
+
+  const effectiveEnabled = enabled && !lowModeEnabled;
+
+  return (
+    <div className="flex items-center gap-3 text-sm text-slate-300" role="group" aria-label="3D 建筑">
+      <span className="min-w-12 text-slate-300">3D 建筑</span>
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          className="h-4 w-4 accent-blue-500"
+          checked={effectiveEnabled}
+          disabled={lowModeEnabled}
+          onChange={(event) => setEnabled(event.target.checked)}
+        />
+        <span className={lowModeEnabled ? 'text-slate-500' : undefined}>
+          {lowModeEnabled ? 'Low 模式已关闭' : '开启'}
+        </span>
+      </label>
+    </div>
+  );
+}
+

--- a/apps/web/src/features/settings/OsmBuildingsToggle.tsx
+++ b/apps/web/src/features/settings/OsmBuildingsToggle.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { usePerformanceModeStore } from '../../state/performanceMode';
 import { useOsmBuildingsStore } from '../../state/osmBuildings';
 
@@ -9,23 +10,28 @@ export default function OsmBuildingsToggle() {
   const setEnabled = useOsmBuildingsStore((state) => state.setEnabled);
 
   const effectiveEnabled = enabled && !lowModeEnabled;
+  const inputId = useId();
+  const statusId = useId();
 
   return (
-    <div className="flex items-center gap-3 text-sm text-slate-300" role="group" aria-label="3D 建筑">
-      <span className="min-w-12 text-slate-300">3D 建筑</span>
-      <label className="flex items-center gap-2">
+    <div className="flex items-center gap-3 text-sm text-slate-300">
+      <label htmlFor={inputId} className="min-w-12 text-slate-300">
+        3D 建筑
+      </label>
+      <div className="flex items-center gap-2">
         <input
+          id={inputId}
           type="checkbox"
           className="h-4 w-4 accent-blue-500"
           checked={effectiveEnabled}
           disabled={lowModeEnabled}
+          aria-describedby={statusId}
           onChange={(event) => setEnabled(event.target.checked)}
         />
-        <span className={lowModeEnabled ? 'text-slate-500' : undefined}>
+        <span id={statusId} className={lowModeEnabled ? 'text-slate-500' : undefined}>
           {lowModeEnabled ? 'Low 模式已关闭' : '开启'}
         </span>
-      </label>
+      </div>
     </div>
   );
 }
-

--- a/apps/web/src/state/osmBuildings.test.ts
+++ b/apps/web/src/state/osmBuildings.test.ts
@@ -14,10 +14,10 @@ function writeStorage(value: unknown) {
 }
 
 describe('osmBuildings store', () => {
-  it('defaults to enabled when localStorage is empty', async () => {
+  it('defaults to disabled when localStorage is empty', async () => {
     localStorage.removeItem(STORAGE_KEY);
     const { useOsmBuildingsStore } = await importFresh();
-    expect(useOsmBuildingsStore.getState().enabled).toBe(true);
+    expect(useOsmBuildingsStore.getState().enabled).toBe(false);
   });
 
   it('restores a persisted enabled flag', async () => {
@@ -30,20 +30,20 @@ describe('osmBuildings store', () => {
     localStorage.removeItem(STORAGE_KEY);
     const { useOsmBuildingsStore } = await importFresh();
 
-    useOsmBuildingsStore.getState().setEnabled(false);
-    expect(useOsmBuildingsStore.getState().enabled).toBe(false);
+    useOsmBuildingsStore.getState().setEnabled(true);
+    expect(useOsmBuildingsStore.getState().enabled).toBe(true);
 
     const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
-    expect(persisted).toEqual({ enabled: false });
+    expect(persisted).toEqual({ enabled: true });
   });
 
   it('toggleEnabled flips enabled', async () => {
     localStorage.removeItem(STORAGE_KEY);
     const { useOsmBuildingsStore } = await importFresh();
 
-    expect(useOsmBuildingsStore.getState().enabled).toBe(true);
-    useOsmBuildingsStore.getState().toggleEnabled();
     expect(useOsmBuildingsStore.getState().enabled).toBe(false);
+    useOsmBuildingsStore.getState().toggleEnabled();
+    expect(useOsmBuildingsStore.getState().enabled).toBe(true);
   });
 
   it('useOsmBuildingsStore subscribes via useSyncExternalStore', async () => {
@@ -56,13 +56,12 @@ describe('osmBuildings store', () => {
     }
 
     render(createElement(EnabledLabel));
-    expect(screen.getByTestId('enabled')).toHaveTextContent('true');
+    expect(screen.getByTestId('enabled')).toHaveTextContent('false');
 
     act(() => {
-      useOsmBuildingsStore.getState().setEnabled(false);
+      useOsmBuildingsStore.getState().setEnabled(true);
     });
 
-    expect(screen.getByTestId('enabled')).toHaveTextContent('false');
+    expect(screen.getByTestId('enabled')).toHaveTextContent('true');
   });
 });
-

--- a/apps/web/src/state/osmBuildings.test.ts
+++ b/apps/web/src/state/osmBuildings.test.ts
@@ -1,0 +1,68 @@
+import { act, render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'digital-earth.osmBuildings';
+
+async function importFresh() {
+  vi.resetModules();
+  return await import('./osmBuildings');
+}
+
+function writeStorage(value: unknown) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+}
+
+describe('osmBuildings store', () => {
+  it('defaults to enabled when localStorage is empty', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { useOsmBuildingsStore } = await importFresh();
+    expect(useOsmBuildingsStore.getState().enabled).toBe(true);
+  });
+
+  it('restores a persisted enabled flag', async () => {
+    writeStorage({ enabled: false });
+    const { useOsmBuildingsStore } = await importFresh();
+    expect(useOsmBuildingsStore.getState().enabled).toBe(false);
+  });
+
+  it('setEnabled updates state and persists', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { useOsmBuildingsStore } = await importFresh();
+
+    useOsmBuildingsStore.getState().setEnabled(false);
+    expect(useOsmBuildingsStore.getState().enabled).toBe(false);
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
+    expect(persisted).toEqual({ enabled: false });
+  });
+
+  it('toggleEnabled flips enabled', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { useOsmBuildingsStore } = await importFresh();
+
+    expect(useOsmBuildingsStore.getState().enabled).toBe(true);
+    useOsmBuildingsStore.getState().toggleEnabled();
+    expect(useOsmBuildingsStore.getState().enabled).toBe(false);
+  });
+
+  it('useOsmBuildingsStore subscribes via useSyncExternalStore', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { useOsmBuildingsStore } = await importFresh();
+
+    function EnabledLabel() {
+      const enabled = useOsmBuildingsStore((state) => state.enabled);
+      return createElement('div', { 'data-testid': 'enabled' }, String(enabled));
+    }
+
+    render(createElement(EnabledLabel));
+    expect(screen.getByTestId('enabled')).toHaveTextContent('true');
+
+    act(() => {
+      useOsmBuildingsStore.getState().setEnabled(false);
+    });
+
+    expect(screen.getByTestId('enabled')).toHaveTextContent('false');
+  });
+});
+

--- a/apps/web/src/state/osmBuildings.ts
+++ b/apps/web/src/state/osmBuildings.ts
@@ -1,0 +1,91 @@
+import { useSyncExternalStore } from 'react';
+
+type OsmBuildingsState = {
+  enabled: boolean;
+  setEnabled: (enabled: boolean) => void;
+  toggleEnabled: () => void;
+};
+
+const STORAGE_KEY = 'digital-earth.osmBuildings';
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+function safeReadEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return true;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === 'boolean') return parsed;
+    if (!parsed || typeof parsed !== 'object') return true;
+    const record = parsed as Record<string, unknown>;
+    return typeof record.enabled === 'boolean' ? record.enabled : true;
+  } catch {
+    return true;
+  }
+}
+
+function safeWriteEnabled(nextEnabled: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ enabled: nextEnabled }));
+  } catch {
+    // ignore write failures (e.g., disabled storage)
+  }
+}
+
+let enabled = safeReadEnabled();
+
+const setEnabled: OsmBuildingsState['setEnabled'] = (next) => {
+  if (Object.is(enabled, next)) return;
+  enabled = next;
+  safeWriteEnabled(next);
+  notify();
+};
+
+const toggleEnabled: OsmBuildingsState['toggleEnabled'] = () => {
+  setEnabled(!enabled);
+};
+
+function getState(): OsmBuildingsState {
+  return { enabled, setEnabled, toggleEnabled };
+}
+
+function setState(partial: Partial<Pick<OsmBuildingsState, 'enabled'>>) {
+  if (typeof partial.enabled !== 'boolean') return;
+  enabled = partial.enabled;
+  safeWriteEnabled(partial.enabled);
+  notify();
+}
+
+function subscribe(listener: Listener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+type Selector<T> = (state: OsmBuildingsState) => T;
+
+type StoreHook = {
+  <T>(selector: Selector<T>): T;
+  getState: typeof getState;
+  setState: typeof setState;
+};
+
+const useOsmBuildingsStoreImpl = <T>(selector: Selector<T>): T =>
+  useSyncExternalStore(
+    subscribe,
+    () => selector(getState()),
+    () => selector(getState()),
+  );
+
+export const useOsmBuildingsStore: StoreHook = Object.assign(useOsmBuildingsStoreImpl, {
+  getState,
+  setState,
+});
+

--- a/apps/web/src/state/osmBuildings.ts
+++ b/apps/web/src/state/osmBuildings.ts
@@ -19,14 +19,14 @@ function notify() {
 function safeReadEnabled(): boolean {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return true;
+    if (!raw) return false;
     const parsed = JSON.parse(raw) as unknown;
     if (typeof parsed === 'boolean') return parsed;
-    if (!parsed || typeof parsed !== 'object') return true;
+    if (!parsed || typeof parsed !== 'object') return false;
     const record = parsed as Record<string, unknown>;
-    return typeof record.enabled === 'boolean' ? record.enabled : true;
+    return typeof record.enabled === 'boolean' ? record.enabled : false;
   } catch {
-    return true;
+    return false;
   }
 }
 
@@ -88,4 +88,3 @@ export const useOsmBuildingsStore: StoreHook = Object.assign(useOsmBuildingsStor
   getState,
   setState,
 });
-


### PR DESCRIPTION
Closes #45

## Summary
- Load Cesium ion OSM Buildings tileset (requestRenderMode-safe) and add it beneath other primitives to avoid interfering with overlays/weather.
- Add a persisted "3D 建筑" toggle; automatically disabled in Low performance mode.
- Add unit tests for the new store/toggle and viewer integration.

## Testing
- pnpm --filter web test -- --coverage
