### PR TITLE
[ST-0013] 接入全球影像底图（Ion + Sentinel-2）并支持切换

### DIFF
--- a/apps/web/src/config/basemaps.test.ts
+++ b/apps/web/src/config/basemaps.test.ts
@@ -16,6 +16,6 @@ describe('basemaps config', () => {
   it('includes at least one WMTS and one URL template option', () => {
     expect(BASEMAPS.some((basemap) => basemap.kind === 'wmts')).toBe(true);
     expect(BASEMAPS.some((basemap) => basemap.kind === 'url-template')).toBe(true);
+    expect(BASEMAPS.some((basemap) => basemap.kind === 'ion')).toBe(true);
   });
 });
-

--- a/apps/web/src/config/basemaps.ts
+++ b/apps/web/src/config/basemaps.ts
@@ -19,9 +19,24 @@ export type BasemapConfig = {
   urlTemplate: string;
   maximumLevel?: number;
   scheme: 'xyz' | 'tms';
+} | {
+  kind: 'ion';
+  id: string;
+  label: string;
+  description?: string;
+  credit: string;
+  style?: 'aerial' | 'aerial-with-labels' | 'road';
 };
 
 export const BASEMAPS = [
+  {
+    kind: 'ion',
+    id: 'ion-world-imagery',
+    label: 'Bing Maps (Cesium ion)',
+    description: 'Cesium Ion World Imagery（asset 2，需要 Ion token）',
+    credit: 'Cesium ion / Bing Maps',
+    style: 'aerial-with-labels',
+  },
   {
     kind: 'wmts',
     id: 'nasa-gibs-blue-marble',
@@ -54,6 +69,7 @@ export const DEFAULT_BASEMAP_ID: BasemapId = 's2cloudless-2021';
 
 export type WmtsBasemap = Extract<BasemapConfig, { kind: 'wmts' }>;
 export type UrlTemplateBasemap = Extract<BasemapConfig, { kind: 'url-template' }>;
+export type IonBasemap = Extract<BasemapConfig, { kind: 'ion' }>;
 
 export function isBasemapId(value: string): value is BasemapId {
   return BASEMAPS.some((basemap) => basemap.id === value);

--- a/apps/web/src/features/viewer/BasemapSelector.test.tsx
+++ b/apps/web/src/features/viewer/BasemapSelector.test.tsx
@@ -18,9 +18,16 @@ test('selects basemap and persists to localStorage', async () => {
   const select = screen.getByRole('combobox', { name: '底图' });
   expect(select).toHaveValue(DEFAULT_BASEMAP_ID);
 
+  expect(screen.getByRole('option', { name: 'Bing Maps (Cesium ion)' })).toBeInTheDocument();
+
   await user.selectOptions(select, 'nasa-gibs-blue-marble');
   expect(select).toHaveValue('nasa-gibs-blue-marble');
 
   expect(localStorage.getItem('digital-earth.basemap')).toMatch(/nasa-gibs-blue-marble/);
   expect(screen.getByLabelText('Basemap description')).toHaveTextContent('Blue Marble');
+
+  await user.selectOptions(select, 'ion-world-imagery');
+  expect(select).toHaveValue('ion-world-imagery');
+  expect(localStorage.getItem('digital-earth.basemap')).toMatch(/ion-world-imagery/);
+  expect(screen.getByLabelText('Basemap description')).toHaveTextContent('Cesium Ion');
 });

--- a/apps/web/src/features/viewer/BasemapSelector.test.tsx
+++ b/apps/web/src/features/viewer/BasemapSelector.test.tsx
@@ -11,9 +11,19 @@ beforeEach(() => {
   useBasemapStore.setState({ basemapId: DEFAULT_BASEMAP_ID });
 });
 
+function readPersistedBasemapId(): string | null {
+  const raw = localStorage.getItem('digital-earth.basemap');
+  if (!raw) return null;
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== 'object') return null;
+  const record = parsed as Record<string, unknown>;
+  const basemapId = record.basemapId;
+  return typeof basemapId === 'string' ? basemapId : null;
+}
+
 test('selects basemap and persists to localStorage', async () => {
   const user = userEvent.setup();
-  render(<BasemapSelector />);
+  render(<BasemapSelector ionEnabled />);
 
   const select = screen.getByRole('combobox', { name: '底图' });
   expect(select).toHaveValue(DEFAULT_BASEMAP_ID);
@@ -23,11 +33,18 @@ test('selects basemap and persists to localStorage', async () => {
   await user.selectOptions(select, 'nasa-gibs-blue-marble');
   expect(select).toHaveValue('nasa-gibs-blue-marble');
 
-  expect(localStorage.getItem('digital-earth.basemap')).toMatch(/nasa-gibs-blue-marble/);
-  expect(screen.getByLabelText('Basemap description')).toHaveTextContent('Blue Marble');
+  expect(readPersistedBasemapId()).toBe('nasa-gibs-blue-marble');
+  expect(select).toHaveAccessibleDescription(/Blue Marble Next Generation/);
 
   await user.selectOptions(select, 'ion-world-imagery');
   expect(select).toHaveValue('ion-world-imagery');
-  expect(localStorage.getItem('digital-earth.basemap')).toMatch(/ion-world-imagery/);
-  expect(screen.getByLabelText('Basemap description')).toHaveTextContent('Cesium Ion');
+  expect(readPersistedBasemapId()).toBe('ion-world-imagery');
+  expect(select).toHaveAccessibleDescription(/Cesium Ion/);
+});
+
+test('disables Cesium ion basemaps when ionEnabled is false', () => {
+  render(<BasemapSelector ionEnabled={false} />);
+
+  const option = screen.getByRole('option', { name: 'Bing Maps (Cesium ion)' });
+  expect(option).toBeDisabled();
 });

--- a/apps/web/src/features/viewer/BasemapSelector.tsx
+++ b/apps/web/src/features/viewer/BasemapSelector.tsx
@@ -1,10 +1,15 @@
 import { BASEMAPS, getBasemapById, isBasemapId } from '../../config/basemaps';
 import { useBasemapStore } from '../../state/basemap';
 
-export function BasemapSelector() {
+type BasemapSelectorProps = {
+  ionEnabled: boolean;
+};
+
+export function BasemapSelector({ ionEnabled }: BasemapSelectorProps) {
   const basemapId = useBasemapStore((state) => state.basemapId);
   const setBasemapId = useBasemapStore((state) => state.setBasemapId);
   const basemap = getBasemapById(basemapId);
+  const descriptionId = basemap?.description ? 'basemap-select-description' : undefined;
 
   return (
     <div className="basemapPanel">
@@ -14,6 +19,7 @@ export function BasemapSelector() {
       <select
         id="basemap-select"
         className="basemapSelect"
+        aria-describedby={descriptionId}
         value={basemapId}
         onChange={(event) => {
           const next = event.target.value;
@@ -21,17 +27,20 @@ export function BasemapSelector() {
         }}
       >
         {BASEMAPS.map((option) => (
-          <option key={option.id} value={option.id}>
+          <option
+            key={option.id}
+            value={option.id}
+            disabled={option.kind === 'ion' && !ionEnabled}
+          >
             {option.label}
           </option>
         ))}
       </select>
       {basemap?.description ? (
-        <div className="basemapHelp" aria-label="Basemap description">
+        <div id="basemap-select-description" className="basemapHelp">
           {basemap.description}
         </div>
       ) : null}
     </div>
   );
 }
-

--- a/apps/web/src/features/viewer/cesiumBasemap.ts
+++ b/apps/web/src/features/viewer/cesiumBasemap.ts
@@ -1,12 +1,14 @@
 import {
+  IonWorldImageryStyle,
   UrlTemplateImageryProvider,
   WebMapTileServiceImageryProvider,
   WebMercatorTilingScheme,
+  createWorldImageryAsync,
   type ImageryProvider,
   type Viewer,
 } from 'cesium';
 
-import { type BasemapConfig, type UrlTemplateBasemap } from '../../config/basemaps';
+import { type BasemapConfig, type IonBasemap, type UrlTemplateBasemap, type WmtsBasemap } from '../../config/basemaps';
 
 function toCesiumUrlTemplate(basemap: UrlTemplateBasemap): string {
   if (basemap.scheme === 'xyz') return basemap.urlTemplate;
@@ -14,7 +16,14 @@ function toCesiumUrlTemplate(basemap: UrlTemplateBasemap): string {
   return basemap.urlTemplate.replaceAll('{y}', '{reverseY}');
 }
 
-export function createImageryProviderForBasemap(basemap: BasemapConfig): ImageryProvider {
+function toIonWorldImageryStyle(style: IonBasemap['style']): IonWorldImageryStyle | undefined {
+  if (style === 'aerial') return IonWorldImageryStyle.AERIAL;
+  if (style === 'aerial-with-labels') return IonWorldImageryStyle.AERIAL_WITH_LABELS;
+  if (style === 'road') return IonWorldImageryStyle.ROAD;
+  return undefined;
+}
+
+export function createImageryProviderForBasemap(basemap: WmtsBasemap | UrlTemplateBasemap): ImageryProvider {
   if (basemap.kind === 'wmts') {
     return new WebMapTileServiceImageryProvider({
       url: basemap.url,
@@ -35,6 +44,17 @@ export function createImageryProviderForBasemap(basemap: BasemapConfig): Imagery
   });
 }
 
+export async function createImageryProviderForBasemapAsync(
+  basemap: BasemapConfig,
+): Promise<ImageryProvider> {
+  if (basemap.kind === 'ion') {
+    const style = toIonWorldImageryStyle(basemap.style);
+    return createWorldImageryAsync(style ? { style } : undefined);
+  }
+
+  return createImageryProviderForBasemap(basemap);
+}
+
 export function setViewerImageryProvider(viewer: Viewer, provider: ImageryProvider): void {
   const baseLayer = viewer.imageryLayers.get(0);
   if (baseLayer) {
@@ -45,7 +65,13 @@ export function setViewerImageryProvider(viewer: Viewer, provider: ImageryProvid
   viewer.scene.requestRender();
 }
 
-export function setViewerBasemap(viewer: Viewer, basemap: BasemapConfig): void {
-  const provider = createImageryProviderForBasemap(basemap);
-  setViewerImageryProvider(viewer, provider);
+export async function setViewerBasemap(viewer: Viewer, basemap: BasemapConfig): Promise<boolean> {
+  try {
+    const provider = await createImageryProviderForBasemapAsync(basemap);
+    setViewerImageryProvider(viewer, provider);
+    return true;
+  } catch (error: unknown) {
+    console.warn('[Digital Earth] failed to set basemap', { basemapId: basemap.id, error });
+    return false;
+  }
 }

--- a/apps/web/src/features/viewer/cesiumBasemap.ts
+++ b/apps/web/src/features/viewer/cesiumBasemap.ts
@@ -10,10 +10,17 @@ import {
 
 import { type BasemapConfig, type IonBasemap, type UrlTemplateBasemap, type WmtsBasemap } from '../../config/basemaps';
 
+export function normalizeTmsTemplate(
+  urlTemplate: string,
+  scheme: 'xyz' | 'tms',
+): string {
+  if (scheme !== 'tms') return urlTemplate;
+  if (urlTemplate.includes('{reverseY}')) return urlTemplate;
+  return urlTemplate.replaceAll('{y}', '{reverseY}');
+}
+
 function toCesiumUrlTemplate(basemap: UrlTemplateBasemap): string {
-  if (basemap.scheme === 'xyz') return basemap.urlTemplate;
-  if (basemap.urlTemplate.includes('{reverseY}')) return basemap.urlTemplate;
-  return basemap.urlTemplate.replaceAll('{y}', '{reverseY}');
+  return normalizeTmsTemplate(basemap.urlTemplate, basemap.scheme);
 }
 
 function toIonWorldImageryStyle(style: IonBasemap['style']): IonWorldImageryStyle | undefined {


### PR DESCRIPTION
Closes #44

## Summary
- Add Cesium ion World Imagery basemap option (`kind: "ion"`) alongside Sentinel-2
- Support async imagery provider creation via `createWorldImageryAsync()` and safe switching
- Keep user selection persisted via existing basemap store (localStorage)

## Testing
- pnpm --filter web test -- --coverage
- pnpm --filter web typecheck
- pnpm --filter web lint
