### PR TITLE
[ST-0035] 云密度派生接口（为 v2 做准备）

### DIFF
--- a/packages/config/tests/test_settings.py
+++ b/packages/config/tests/test_settings.py
@@ -126,6 +126,36 @@ def test_pipeline_precip_type_threshold_loads_and_env_overrides(
     assert settings.pipeline.precip_type_temp_threshold_c == pytest.approx(2.25)
 
 
+def test_pipeline_cloud_density_thresholds_load_and_env_overrides(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_dir = tmp_path / "config"
+    base = _base_config()
+    base["pipeline"]["cloud_density_rh0"] = 80.0
+    base["pipeline"]["cloud_density_rh1"] = 95.0
+    _write_config(config_dir, "dev", base)
+
+    monkeypatch.setenv("DIGITAL_EARTH_ENV", "dev")
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("DIGITAL_EARTH_DB_USER", "app")
+    monkeypatch.setenv("DIGITAL_EARTH_DB_PASSWORD", "secret")
+
+    settings = Settings()
+    assert settings.pipeline.cloud_density_rh0 == pytest.approx(80.0)
+    assert settings.pipeline.cloud_density_rh1 == pytest.approx(95.0)
+
+    monkeypatch.setenv("DIGITAL_EARTH_PIPELINE_CLOUD_DENSITY_RH0", "0.75")
+    monkeypatch.setenv("DIGITAL_EARTH_PIPELINE_CLOUD_DENSITY_RH1", "0.9")
+    settings = Settings()
+    assert settings.pipeline.cloud_density_rh0 == pytest.approx(0.75)
+    assert settings.pipeline.cloud_density_rh1 == pytest.approx(0.9)
+
+    monkeypatch.setenv("DIGITAL_EARTH_PIPELINE_CLOUD_DENSITY_RH0", "0.8")
+    monkeypatch.setenv("DIGITAL_EARTH_PIPELINE_CLOUD_DENSITY_RH1", "95")
+    with pytest.raises(ValueError, match="consistent units"):
+        Settings()
+
+
 def test_cors_origins_parses_string(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/services/data-pipeline/src/derived/cloud_density.py
+++ b/services/data-pipeline/src/derived/cloud_density.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Iterable
+
+import numpy as np
+import xarray as xr
+
+
+class CloudDensityDerivationError(RuntimeError):
+    pass
+
+
+RH_VAR_CANDIDATES: Final[tuple[str, ...]] = (
+    "rh",
+    "r",
+    "relative_humidity",
+    "relativeHumidity",
+    "RELATIVE_HUMIDITY",
+    "RH",
+)
+
+
+def _normalize_units_text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _resolve_rh_fraction_scale(*, units: str, grid: np.ndarray) -> float:
+    """Return the multiplicative factor to convert RH into [0, 1]."""
+
+    normalized_units = _normalize_units_text(units).lower()
+    if normalized_units:
+        if "%" in normalized_units or "percent" in normalized_units:
+            return 0.01
+        if normalized_units in {"1"} or "fraction" in normalized_units:
+            return 1.0
+
+    values = np.asarray(grid, dtype=np.float32)
+    mask = np.isfinite(values)
+    if not mask.any():
+        return 1.0
+
+    vmax = float(np.nanmax(values))
+    if vmax > 1.5:
+        return 0.01
+    return 1.0
+
+
+def normalize_relative_humidity(da: xr.DataArray) -> xr.DataArray:
+    """Normalize RH into a float32 fraction in [0, 1] when possible."""
+
+    raw = np.asarray(da.values, dtype=np.float32)
+    scale = _resolve_rh_fraction_scale(
+        units=_normalize_units_text(da.attrs.get("units")), grid=raw
+    )
+    out = xr.DataArray(
+        (raw * scale).astype(np.float32, copy=False),
+        dims=da.dims,
+        coords=da.coords,
+        name=da.name,
+        attrs=dict(da.attrs),
+    )
+    out.attrs["units"] = "1"
+    out.attrs.setdefault("standard_name", "relative_humidity")
+    return out
+
+
+def smoothstep(edge0: float, edge1: float, x: xr.DataArray) -> xr.DataArray:
+    denom = float(edge1) - float(edge0)
+    if denom == 0.0:
+        raise CloudDensityDerivationError("smoothstep requires edge1 != edge0")
+    t = ((x - float(edge0)) / denom).clip(min=0.0, max=1.0)
+    return t * t * (3.0 - 2.0 * t)
+
+
+@dataclass(frozen=True)
+class CloudDensityThresholds:
+    rh0: float
+    rh1: float
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        rh0: float | None = None,
+        rh1: float | None = None,
+    ) -> "CloudDensityThresholds":
+        if rh0 is None or rh1 is None:
+            from config import get_settings
+
+            settings = get_settings()
+            if rh0 is None:
+                rh0 = float(settings.pipeline.cloud_density_rh0)
+            if rh1 is None:
+                rh1 = float(settings.pipeline.cloud_density_rh1)
+
+        rh0_f = float(rh0)
+        rh1_f = float(rh1)
+
+        if (rh0_f > 1.0) != (rh1_f > 1.0):
+            raise CloudDensityDerivationError(
+                "RH0/RH1 must use consistent units (both fraction ≤ 1 or both percent > 1)"
+            )
+
+        if rh0_f > 1.0:
+            rh0_f /= 100.0
+            rh1_f /= 100.0
+
+        if not (0.0 <= rh0_f < rh1_f <= 1.0):
+            raise CloudDensityDerivationError(
+                f"Invalid RH thresholds after normalization: rh0={rh0_f}, rh1={rh1_f}"
+            )
+
+        return cls(rh0=rh0_f, rh1=rh1_f)
+
+
+def derive_cloud_density_from_rh(
+    rh: xr.DataArray,
+    *,
+    thresholds: CloudDensityThresholds | None = None,
+) -> xr.DataArray:
+    """Derive cloud density from RH via smoothstep.
+
+    The returned density is float32, named `cloud_density`, and clamped to [0, 1]
+    for all finite values.
+    """
+
+    resolved = thresholds or CloudDensityThresholds.resolve()
+    rh_frac = normalize_relative_humidity(rh)
+    density = smoothstep(resolved.rh0, resolved.rh1, rh_frac)
+    density = density.clip(min=0.0, max=1.0).astype(np.float32, copy=False)
+    density.name = "cloud_density"
+    density.attrs = {
+        "units": "1",
+        "long_name": "Cloud density derived from relative humidity",
+        "rh0": float(resolved.rh0),
+        "rh1": float(resolved.rh1),
+        "mapping": "smoothstep(rh0, rh1, rh)",
+    }
+    return density
+
+
+def _descriptor_text(name: str, da: xr.DataArray) -> str:
+    parts: Iterable[object] = (
+        name,
+        da.name,
+        da.attrs.get("standard_name"),
+        da.attrs.get("long_name"),
+    )
+    return " ".join(str(part or "") for part in parts).lower()
+
+
+def resolve_rh_variable_name(ds: xr.Dataset, *, preferred: str | None = None) -> str:
+    if preferred is not None:
+        key = str(preferred).strip()
+        if key == "":
+            raise CloudDensityDerivationError("RH variable name must not be empty")
+        if key not in ds.data_vars:
+            raise CloudDensityDerivationError(
+                f"RH variable {key!r} not found; available={list(ds.data_vars)}"
+            )
+        return key
+
+    present = {name.lower(): name for name in ds.data_vars}
+    for candidate in RH_VAR_CANDIDATES:
+        found = present.get(candidate.lower())
+        if found is not None:
+            return found
+
+    for name in ds.data_vars:
+        if "relative_humidity" in _descriptor_text(name, ds[name]):
+            return name
+        if "relative humidity" in _descriptor_text(name, ds[name]):
+            return name
+
+    raise CloudDensityDerivationError(
+        f"Unable to infer RH variable; tried={list(RH_VAR_CANDIDATES)} available={list(ds.data_vars)}"
+    )
+
+
+def derive_cloud_density_dataset(
+    ds: xr.Dataset,
+    *,
+    rh_variable: str | None = None,
+    thresholds: CloudDensityThresholds | None = None,
+) -> xr.Dataset:
+    name = resolve_rh_variable_name(ds, preferred=rh_variable)
+    density = derive_cloud_density_from_rh(ds[name], thresholds=thresholds)
+    return xr.Dataset({"cloud_density": density})

--- a/services/data-pipeline/src/volume/__init__.py
+++ b/services/data-pipeline/src/volume/__init__.py
@@ -1,0 +1,1 @@
+"""Volume intermediate data exporters (for Volume API)."""

--- a/services/data-pipeline/src/volume/__main__.py
+++ b/services/data-pipeline/src/volume/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from volume.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/data-pipeline/src/volume/cli.py
+++ b/services/data-pipeline/src/volume/cli.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from datacube.storage import open_datacube
+from volume.cloud_density import (
+    DEFAULT_CLOUD_DENSITY_LAYER,
+    export_cloud_density_slices,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m volume",
+        description="Export cloud density slices for Volume API consumption.",
+    )
+    parser.add_argument(
+        "--datacube", required=True, help="Path to a NetCDF/Zarr DataCube containing RH"
+    )
+    parser.add_argument(
+        "--output-dir", required=True, help="Directory to write intermediate files into"
+    )
+    parser.add_argument("--valid-time", default=None, help="ISO8601 timestamp")
+    parser.add_argument(
+        "--layer",
+        default=DEFAULT_CLOUD_DENSITY_LAYER,
+        help=f"Output layer path (default: {DEFAULT_CLOUD_DENSITY_LAYER})",
+    )
+    parser.add_argument(
+        "--rh-var",
+        default=None,
+        help="RH variable name in DataCube (default: infer from dataset)",
+    )
+    parser.add_argument("--rh0", type=float, default=None, help="Lower RH threshold")
+    parser.add_argument("--rh1", type=float, default=None, help="Upper RH threshold")
+    parser.add_argument(
+        "--format",
+        choices=("netcdf", "zarr"),
+        default="netcdf",
+        help="Output format (default: netcdf)",
+    )
+    parser.add_argument(
+        "--manifest",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Write a manifest.json next to slice files (default: enabled)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    cube_path = Path(args.datacube)
+    output_dir = Path(args.output_dir)
+
+    ds = open_datacube(cube_path)
+    try:
+        result = export_cloud_density_slices(
+            ds,
+            output_dir,
+            valid_time=args.valid_time,
+            layer=args.layer,
+            rh_variable=args.rh_var,
+            rh0=args.rh0,
+            rh1=args.rh1,
+            output_format=args.format,
+            write_manifest=bool(args.manifest),
+        )
+    finally:
+        ds.close()
+
+    payload = {
+        "schema_version": 1,
+        "layer": result.layer,
+        "time": result.time,
+        "rh0": result.rh0,
+        "rh1": result.rh1,
+        "levels": result.levels,
+        "files": [str(path) for path in result.files],
+        "manifest": str(result.manifest) if result.manifest is not None else None,
+    }
+    print(json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True))
+    return 0

--- a/services/data-pipeline/src/volume/cli.py
+++ b/services/data-pipeline/src/volume/cli.py
@@ -34,8 +34,18 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="RH variable name in DataCube (default: infer from dataset)",
     )
-    parser.add_argument("--rh0", type=float, default=None, help="Lower RH threshold")
-    parser.add_argument("--rh1", type=float, default=None, help="Upper RH threshold")
+    parser.add_argument(
+        "--rh0",
+        type=float,
+        default=None,
+        help="Lower RH threshold (fraction [0,1] or percent [0,100])",
+    )
+    parser.add_argument(
+        "--rh1",
+        type=float,
+        default=None,
+        help="Upper RH threshold (fraction [0,1] or percent [0,100])",
+    )
     parser.add_argument(
         "--format",
         choices=("netcdf", "zarr"),

--- a/services/data-pipeline/src/volume/cloud_density.py
+++ b/services/data-pipeline/src/volume/cloud_density.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final, Optional
+
+import numpy as np
+import xarray as xr
+
+from datacube.storage import write_datacube
+from derived.cloud_density import CloudDensityThresholds, derive_cloud_density_from_rh
+
+
+class CloudDensityExportError(RuntimeError):
+    pass
+
+
+DEFAULT_CLOUD_DENSITY_LAYER: Final[str] = "ecmwf/cloud_density"
+
+_LAYER_SEGMENT_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_]+$")
+_TIME_KEY_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9TZ-]+$")
+_LEVEL_KEY_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+_SURFACE_LEVEL_ALIASES: Final[set[str]] = {"sfc", "surface"}
+
+
+def _validate_layer(value: str) -> str:
+    normalized = (value or "").strip().strip("/")
+    if normalized == "":
+        raise ValueError("layer must not be empty")
+
+    segments = normalized.split("/")
+    invalid_segments = [
+        segment
+        for segment in segments
+        if not segment or _LAYER_SEGMENT_RE.fullmatch(segment) is None
+    ]
+    if invalid_segments:
+        raise ValueError("layer contains unsafe characters")
+    return "/".join(segments)
+
+
+def _validate_time_key(value: str) -> str:
+    normalized = (value or "").strip()
+    if normalized == "":
+        raise ValueError("time_key must not be empty")
+    if _TIME_KEY_RE.fullmatch(normalized) is None:
+        raise ValueError("time_key contains unsafe characters")
+    return normalized
+
+
+def _validate_level_key(value: str) -> str:
+    normalized = (value or "").strip()
+    if normalized == "":
+        raise ValueError("level_key must not be empty")
+    if _LEVEL_KEY_RE.fullmatch(normalized) is None:
+        raise ValueError("level_key contains unsafe characters")
+    return normalized
+
+
+def _ensure_relative_to_base(*, base_dir: Path, path: Path, label: str) -> None:
+    if not path.is_relative_to(base_dir):
+        raise ValueError(f"{label} escapes output_dir")
+
+
+def _normalize_time_key(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _parse_time(value: object) -> datetime:
+    if isinstance(value, np.datetime64):
+        # DataCube stores time as UTC-naive datetime64; treat as UTC.
+        text = np.datetime_as_string(value.astype("datetime64[s]"), unit="s")
+        return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+
+    if isinstance(value, datetime):
+        dt = value
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    raw = str(value or "").strip()
+    if raw == "":
+        raise ValueError("valid_time must not be empty")
+
+    candidate = raw
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    except ValueError:
+        try:
+            return datetime.strptime(raw, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+        except ValueError as exc:
+            raise ValueError("valid_time must be an ISO8601 timestamp") from exc
+
+
+def _resolve_time_index(ds: xr.Dataset, valid_time: object | None) -> tuple[int, str]:
+    if "time" not in ds.coords:
+        raise CloudDensityExportError("Dataset missing required coordinate: time")
+
+    values = np.asarray(ds["time"].values)
+    if values.size == 0:
+        raise CloudDensityExportError("time coordinate is empty")
+
+    dt = _parse_time(values[0] if valid_time is None else valid_time)
+    key = _validate_time_key(_normalize_time_key(dt))
+
+    target = np.datetime64(dt.strftime("%Y-%m-%dT%H:%M:%S"))
+    matches = np.where(values.astype("datetime64[s]") == target)[0]
+    if matches.size == 0:
+        sample = [_normalize_time_key(_parse_time(item)) for item in values[:3]]
+        raise CloudDensityExportError(
+            f"valid_time not found in dataset: {dt.isoformat()} (sample={sample})"
+        )
+    return int(matches[0]), key
+
+
+def _level_key(value: object) -> str:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _SURFACE_LEVEL_ALIASES:
+            return "sfc"
+        return _validate_level_key(normalized)
+
+    if isinstance(value, (int, float, np.number)):
+        numeric = float(value)
+        if not np.isfinite(numeric):
+            raise CloudDensityExportError("level coordinate contains non-finite values")
+        if abs(numeric - round(numeric)) < 1e-6:
+            return _validate_level_key(str(int(round(numeric))))
+        return _validate_level_key(str(numeric))
+
+    return _validate_level_key(str(value))
+
+
+@dataclass(frozen=True)
+class CloudDensityExportResult:
+    layer: str
+    time: str
+    rh0: float
+    rh1: float
+    levels: tuple[str, ...]
+    files: tuple[Path, ...]
+    manifest: Optional[Path] = None
+
+
+def export_cloud_density_slices(
+    ds: xr.Dataset,
+    output_dir: str | Path,
+    *,
+    valid_time: object | None = None,
+    layer: str = DEFAULT_CLOUD_DENSITY_LAYER,
+    rh_variable: str | None = None,
+    rh0: float | None = None,
+    rh1: float | None = None,
+    output_format: str = "netcdf",
+    write_manifest: bool = True,
+) -> CloudDensityExportResult:
+    """Export per-pressure-level cloud density files for Volume API.
+
+    Output layout:
+      <output_dir>/<layer>/<time_key>/<level_key>.nc  (or .zarr)
+    """
+
+    if output_format not in {"netcdf", "zarr"}:
+        raise ValueError("output_format must be either 'netcdf' or 'zarr'")
+
+    thresholds = CloudDensityThresholds.resolve(rh0=rh0, rh1=rh1)
+    layer_norm = _validate_layer(layer)
+
+    if "level" not in ds.coords:
+        raise CloudDensityExportError("Dataset missing required coordinate: level")
+    levels = np.asarray(ds["level"].values)
+    if levels.size == 0:
+        raise CloudDensityExportError("level coordinate is empty")
+
+    time_index, time_key = _resolve_time_index(ds, valid_time)
+
+    base = Path(output_dir).resolve()
+    layer_dir = (base / layer_norm).resolve()
+    _ensure_relative_to_base(base_dir=base, path=layer_dir, label="layer")
+    time_dir = (layer_dir / time_key).resolve()
+    _ensure_relative_to_base(base_dir=base, path=time_dir, label="time_key")
+    time_dir.mkdir(parents=True, exist_ok=True)
+
+    if rh_variable is None:
+        # Late import so volume exporter doesn't own RH var inference logic.
+        from derived.cloud_density import resolve_rh_variable_name
+
+        rh_variable = resolve_rh_variable_name(ds)
+
+    if rh_variable not in ds.data_vars:
+        raise CloudDensityExportError(
+            f"RH variable {rh_variable!r} not found; available={list(ds.data_vars)}"
+        )
+    rh = ds[rh_variable]
+    required_dims = {"time", "level", "lat", "lon"}
+    if not required_dims.issubset(set(rh.dims)):
+        raise CloudDensityExportError(
+            f"RH variable missing required dims={sorted(required_dims)}; got dims={list(rh.dims)}"
+        )
+
+    files: list[Path] = []
+    level_keys: list[str] = []
+    ext = "nc" if output_format == "netcdf" else "zarr"
+    for level_index, level_value in enumerate(levels.tolist()):
+        level_key = _level_key(level_value)
+        level_keys.append(level_key)
+
+        target = (time_dir / f"{level_key}.{ext}").resolve()
+        _ensure_relative_to_base(base_dir=base, path=target, label="slice")
+
+        rh_slice = rh.isel(time=[int(time_index)], level=[int(level_index)])
+        density = derive_cloud_density_from_rh(rh_slice, thresholds=thresholds)
+        out = xr.Dataset({"cloud_density": density})
+        out.attrs = {
+            "schema": "digital-earth.volume-slice",
+            "schema_version": 1,
+            "variable": "cloud_density",
+            "source_variable": str(rh_variable),
+            "rh0": float(thresholds.rh0),
+            "rh1": float(thresholds.rh1),
+        }
+        write_datacube(out, target, format=output_format)
+        files.append(target)
+
+    manifest_path: Optional[Path] = None
+    if write_manifest:
+        manifest_path = (time_dir / "manifest.json").resolve()
+        _ensure_relative_to_base(base_dir=base, path=manifest_path, label="manifest")
+        manifest_payload = {
+            "schema": "digital-earth.volume-slices",
+            "schema_version": 1,
+            "layer": layer_norm,
+            "time": time_key,
+            "variable": "cloud_density",
+            "source_variable": str(rh_variable),
+            "rh0": float(thresholds.rh0),
+            "rh1": float(thresholds.rh1),
+            "levels": level_keys,
+            "files": [path.name for path in files],
+        }
+        manifest_path.write_text(
+            json.dumps(
+                manifest_payload,
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    return CloudDensityExportResult(
+        layer=layer_norm,
+        time=time_key,
+        rh0=float(thresholds.rh0),
+        rh1=float(thresholds.rh1),
+        levels=tuple(level_keys),
+        files=tuple(files),
+        manifest=manifest_path,
+    )

--- a/services/data-pipeline/tests/test_cloud_density_derivation.py
+++ b/services/data-pipeline/tests/test_cloud_density_derivation.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import sys
+import json
+import runpy
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from datacube.storage import open_datacube, write_datacube
+from derived.cloud_density import (
+    CloudDensityDerivationError,
+    CloudDensityThresholds,
+    derive_cloud_density_from_rh,
+    derive_cloud_density_dataset,
+    normalize_relative_humidity,
+    resolve_rh_variable_name,
+    smoothstep,
+)
+from volume.cli import main as volume_main
+from volume.cloud_density import CloudDensityExportError, export_cloud_density_slices
+from volume import cloud_density as volume_cloud_density
+
+
+def test_smoothstep_matches_reference() -> None:
+    x = xr.DataArray(
+        np.array([-1.0, 0.0, 0.5, 1.0, 2.0], dtype=np.float32), dims=("x",)
+    )
+    out = smoothstep(0.0, 1.0, x)
+    expected = np.array([0.0, 0.0, 0.5, 1.0, 1.0], dtype=np.float32)
+    assert np.allclose(out.values, expected, atol=1e-6)
+
+
+def test_smoothstep_rejects_equal_edges() -> None:
+    x = xr.DataArray(np.array([0.0], dtype=np.float32), dims=("x",))
+    with pytest.raises(CloudDensityDerivationError, match="edge1 != edge0"):
+        smoothstep(0.5, 0.5, x)
+
+
+def test_normalize_relative_humidity_converts_percent_units() -> None:
+    rh = xr.DataArray(
+        np.array([0.0, 50.0, 100.0], dtype=np.float32),
+        dims=("x",),
+        attrs={"units": "%"},
+        name="r",
+    )
+    out = normalize_relative_humidity(rh)
+    assert out.dtype == np.float32
+    assert out.attrs["units"] == "1"
+    assert out.attrs["standard_name"] == "relative_humidity"
+    assert np.allclose(out.values, np.array([0.0, 0.5, 1.0], dtype=np.float32))
+
+
+def test_normalize_relative_humidity_heuristic_detects_percent_when_units_missing() -> (
+    None
+):
+    rh = xr.DataArray(
+        np.array([0.0, 80.0, 100.0], dtype=np.float32),
+        dims=("x",),
+        name="r",
+    )
+    out = normalize_relative_humidity(rh)
+    assert np.allclose(out.values, np.array([0.0, 0.8, 1.0], dtype=np.float32))
+
+
+def test_normalize_relative_humidity_heuristic_keeps_fraction_when_units_missing() -> (
+    None
+):
+    rh = xr.DataArray(
+        np.array([0.0, 0.25, 0.5, 1.0], dtype=np.float32),
+        dims=("x",),
+        name="r",
+    )
+    out = normalize_relative_humidity(rh)
+    assert np.allclose(out.values, rh.values)
+
+
+def test_normalize_relative_humidity_all_missing_values_keeps_scale() -> None:
+    rh = xr.DataArray(
+        np.array([np.nan, np.nan], dtype=np.float32),
+        dims=("x",),
+        name="r",
+    )
+    out = normalize_relative_humidity(rh)
+    assert np.all(np.isnan(out.values))
+
+
+def test_cloud_density_thresholds_accept_fraction_or_percent() -> None:
+    thresholds = CloudDensityThresholds.resolve(rh0=0.8, rh1=0.95)
+    assert thresholds.rh0 == pytest.approx(0.8)
+    assert thresholds.rh1 == pytest.approx(0.95)
+
+    thresholds = CloudDensityThresholds.resolve(rh0=80.0, rh1=95.0)
+    assert thresholds.rh0 == pytest.approx(0.8)
+    assert thresholds.rh1 == pytest.approx(0.95)
+
+    with pytest.raises(CloudDensityDerivationError, match="consistent units"):
+        CloudDensityThresholds.resolve(rh0=0.8, rh1=95.0)
+
+    with pytest.raises(CloudDensityDerivationError, match="Invalid RH thresholds"):
+        CloudDensityThresholds.resolve(rh0=0.95, rh1=0.8)
+
+
+def test_cloud_density_thresholds_load_from_shared_settings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    base = {
+        "api": {"host": "0.0.0.0", "port": 8000, "debug": True, "cors_origins": []},
+        "pipeline": {
+            "workers": 2,
+            "batch_size": 100,
+            "cloud_density_rh0": 0.7,
+            "cloud_density_rh1": 0.9,
+        },
+        "web": {"api_base_url": "http://localhost:8000"},
+        "database": {"host": "localhost", "port": 5432, "name": "digital_earth"},
+        "redis": {"host": "localhost", "port": 6379},
+        "storage": {"tiles_bucket": "tiles", "raw_bucket": "raw"},
+    }
+    (config_dir / "dev.json").write_text(json.dumps(base), encoding="utf-8")
+
+    monkeypatch.setenv("DIGITAL_EARTH_ENV", "dev")
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("DIGITAL_EARTH_DB_USER", "app")
+    monkeypatch.setenv("DIGITAL_EARTH_DB_PASSWORD", "secret")
+
+    from config import get_settings
+
+    get_settings.cache_clear()
+    thresholds = CloudDensityThresholds.resolve()
+    assert thresholds.rh0 == pytest.approx(0.7)
+    assert thresholds.rh1 == pytest.approx(0.9)
+
+
+def test_resolve_rh_variable_name_prefers_known_candidates() -> None:
+    ds = xr.Dataset(
+        {
+            "t": xr.DataArray(np.zeros((1,), dtype=np.float32), dims=("x",)),
+            "r": xr.DataArray(np.ones((1,), dtype=np.float32), dims=("x",)),
+        }
+    )
+    assert resolve_rh_variable_name(ds) == "r"
+
+
+def test_resolve_rh_variable_name_uses_standard_name_fallback() -> None:
+    ds = xr.Dataset(
+        {
+            "foo": xr.DataArray(
+                np.ones((1,), dtype=np.float32),
+                dims=("x",),
+                attrs={"standard_name": "relative_humidity"},
+            ),
+        }
+    )
+    assert resolve_rh_variable_name(ds) == "foo"
+
+
+def test_resolve_rh_variable_name_honors_preferred_and_errors() -> None:
+    ds = xr.Dataset(
+        {
+            "r": xr.DataArray(np.ones((1,), dtype=np.float32), dims=("x",)),
+        }
+    )
+    assert resolve_rh_variable_name(ds, preferred="r") == "r"
+
+    with pytest.raises(CloudDensityDerivationError, match="must not be empty"):
+        resolve_rh_variable_name(ds, preferred="   ")
+
+    with pytest.raises(CloudDensityDerivationError, match="not found"):
+        resolve_rh_variable_name(ds, preferred="missing")
+
+
+def test_resolve_rh_variable_name_long_name_fallback_and_missing_raises() -> None:
+    ds = xr.Dataset(
+        {
+            "foo": xr.DataArray(
+                np.ones((1,), dtype=np.float32),
+                dims=("x",),
+                attrs={"long_name": "Relative Humidity"},
+            ),
+        }
+    )
+    assert resolve_rh_variable_name(ds) == "foo"
+
+    ds_missing = xr.Dataset(
+        {
+            "bar": xr.DataArray(np.ones((1,), dtype=np.float32), dims=("x",)),
+        }
+    )
+    with pytest.raises(
+        CloudDensityDerivationError, match="Unable to infer RH variable"
+    ):
+        resolve_rh_variable_name(ds_missing)
+
+
+def test_derive_cloud_density_from_rh_clamps_to_unit_interval() -> None:
+    rh = xr.DataArray(
+        np.array([0.7, 0.8, 0.875, 0.95, 1.1], dtype=np.float32),
+        dims=("x",),
+        name="rh",
+        attrs={"units": "1"},
+    )
+    thresholds = CloudDensityThresholds.resolve(rh0=0.8, rh1=0.95)
+    density = derive_cloud_density_from_rh(rh, thresholds=thresholds)
+
+    assert density.name == "cloud_density"
+    assert density.dtype == np.float32
+    assert density.attrs["units"] == "1"
+    assert np.all(np.isfinite(density.values))
+    assert np.all(density.values >= 0.0)
+    assert np.all(density.values <= 1.0)
+    assert density.values[0] == pytest.approx(0.0)
+    assert density.values[1] == pytest.approx(0.0)
+    assert density.values[2] == pytest.approx(0.5, abs=1e-6)
+    assert density.values[3] == pytest.approx(1.0)
+    assert density.values[4] == pytest.approx(1.0)
+
+
+def test_derive_cloud_density_dataset_wraps_dataset() -> None:
+    ds = xr.Dataset(
+        {
+            "r": xr.DataArray(
+                np.array([0.0, 100.0], dtype=np.float32),
+                dims=("x",),
+                attrs={"units": "%"},
+            )
+        }
+    )
+    thresholds = CloudDensityThresholds.resolve(rh0=80.0, rh1=100.0)
+    out = derive_cloud_density_dataset(ds, rh_variable="r", thresholds=thresholds)
+    assert list(out.data_vars) == ["cloud_density"]
+    assert float(out["cloud_density"].min()) >= 0.0
+    assert float(out["cloud_density"].max()) <= 1.0
+
+
+def _rh_datacube_dataset(*, units: str = "%") -> xr.Dataset:
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = np.array([850.0, 700.0], dtype=np.float32)
+    lat = np.array([10.0, 20.0], dtype=np.float32)
+    lon = np.array([30.0, 40.0], dtype=np.float32)
+    # shape: time, level, lat, lon
+    data = np.array(
+        [
+            [
+                [[0.0, 50.0], [80.0, 100.0]],
+                [[10.0, 60.0], [90.0, 100.0]],
+            ]
+        ],
+        dtype=np.float32,
+    )
+    return xr.Dataset(
+        {
+            "r": xr.DataArray(
+                data, dims=("time", "level", "lat", "lon"), attrs={"units": units}
+            )
+        },
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+
+
+def test_export_cloud_density_slices_writes_per_level_files(tmp_path: Path) -> None:
+    ds = _rh_datacube_dataset(units="%")
+    result = export_cloud_density_slices(
+        ds,
+        tmp_path,
+        layer="ecmwf/cloud_density",
+        rh0=80.0,
+        rh1=100.0,
+        output_format="netcdf",
+        write_manifest=True,
+    )
+
+    out_dir = tmp_path / "ecmwf" / "cloud_density" / result.time
+    assert out_dir.is_dir()
+    assert result.manifest is not None
+    assert result.manifest.exists()
+    assert len(result.levels) == 2
+    assert len(result.files) == 2
+
+    with open_datacube(result.files[0]) as slice_ds:
+        assert "cloud_density" in slice_ds.data_vars
+        da = slice_ds["cloud_density"]
+        assert da.dtype == np.float32
+        assert set(da.dims) == {"time", "level", "lat", "lon"}
+        assert slice_ds.sizes["time"] == 1
+        assert slice_ds.sizes["level"] == 1
+        assert float(np.nanmin(da.values)) >= 0.0
+        assert float(np.nanmax(da.values)) <= 1.0
+
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema"] == "digital-earth.volume-slices"
+    assert manifest["layer"] == "ecmwf/cloud_density"
+    assert manifest["levels"] == list(result.levels)
+
+
+def test_volume_export_input_validation_errors(tmp_path: Path) -> None:
+    ds = _rh_datacube_dataset(units="%")
+    with pytest.raises(ValueError, match="layer must not be empty"):
+        export_cloud_density_slices(
+            ds,
+            tmp_path,
+            layer="",
+            rh0=80.0,
+            rh1=100.0,
+        )
+
+    with pytest.raises(ValueError, match="unsafe"):
+        export_cloud_density_slices(
+            ds,
+            tmp_path,
+            layer="ecmwf/../cloud_density",
+            rh0=80.0,
+            rh1=100.0,
+        )
+
+    with pytest.raises(ValueError, match="output_format"):
+        export_cloud_density_slices(
+            ds,
+            tmp_path,
+            layer="ecmwf/cloud_density",
+            rh0=80.0,
+            rh1=100.0,
+            output_format="nope",
+        )
+
+    with pytest.raises(CloudDensityExportError, match="RH variable.*not found"):
+        export_cloud_density_slices(
+            ds,
+            tmp_path,
+            layer="ecmwf/cloud_density",
+            rh_variable="missing",
+            rh0=80.0,
+            rh1=100.0,
+        )
+
+    ds_missing_level = ds.rename({"level": "plev"})
+    with pytest.raises(CloudDensityExportError, match="coordinate: level"):
+        export_cloud_density_slices(
+            ds_missing_level,
+            tmp_path,
+            layer="ecmwf/cloud_density",
+            rh0=80.0,
+            rh1=100.0,
+        )
+
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = np.array([], dtype=np.float32)
+    lat = np.array([0.0], dtype=np.float32)
+    lon = np.array([0.0], dtype=np.float32)
+    ds_empty_level = xr.Dataset(
+        {
+            "r": xr.DataArray(
+                np.empty((1, 0, 1, 1), dtype=np.float32),
+                dims=("time", "level", "lat", "lon"),
+                attrs={"units": "%"},
+            )
+        },
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+    with pytest.raises(CloudDensityExportError, match="level coordinate is empty"):
+        export_cloud_density_slices(
+            ds_empty_level,
+            tmp_path,
+            layer="ecmwf/cloud_density",
+            rh0=80.0,
+            rh1=100.0,
+        )
+
+    ds_missing_dims = xr.Dataset(
+        {
+            "r": xr.DataArray(
+                np.ones((1, 1), dtype=np.float32),
+                dims=("time", "level"),
+                attrs={"units": "%"},
+            )
+        },
+        coords={"time": time, "level": np.array([850.0], dtype=np.float32)},
+    )
+    with pytest.raises(CloudDensityExportError, match="missing required dims"):
+        export_cloud_density_slices(
+            ds_missing_dims,
+            tmp_path,
+            layer="ecmwf/cloud_density",
+            rh0=80.0,
+            rh1=100.0,
+        )
+
+
+def test_volume_helpers_cover_error_paths(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="time_key must not be empty"):
+        volume_cloud_density._validate_time_key("")  # noqa: SLF001
+    with pytest.raises(ValueError, match="unsafe"):
+        volume_cloud_density._validate_time_key("bad/time")  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="level_key must not be empty"):
+        volume_cloud_density._validate_level_key("")  # noqa: SLF001
+    with pytest.raises(ValueError, match="unsafe"):
+        volume_cloud_density._validate_level_key("850/700")  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="escapes output_dir"):
+        volume_cloud_density._ensure_relative_to_base(  # noqa: SLF001
+            base_dir=tmp_path, path=tmp_path.parent, label="x"
+        )
+
+
+def test_volume_parse_time_variants_and_errors() -> None:
+    assert (
+        volume_cloud_density._parse_time(np.datetime64("2026-01-01T00:00:00")).tzinfo  # noqa: SLF001
+        == timezone.utc
+    )
+    assert (
+        volume_cloud_density._parse_time(datetime(2026, 1, 1, 0, 0, 0)).tzinfo
+        == timezone.utc
+    )  # noqa: SLF001
+    assert (
+        volume_cloud_density._parse_time(
+            datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        ).tzinfo
+        == timezone.utc
+    )
+    assert (
+        volume_cloud_density._parse_time("2026-01-01T00:00:00Z").tzinfo == timezone.utc
+    )  # noqa: SLF001
+    assert volume_cloud_density._parse_time("20260101T000000Z").tzinfo == timezone.utc  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        volume_cloud_density._parse_time("")  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="ISO8601"):
+        volume_cloud_density._parse_time("not-a-time")  # noqa: SLF001
+
+
+def test_volume_resolve_time_index_error_paths() -> None:
+    with pytest.raises(CloudDensityExportError, match="coordinate: time"):
+        volume_cloud_density._resolve_time_index(  # noqa: SLF001
+            xr.Dataset(coords={"level": [1]}), valid_time=None
+        )
+
+    with pytest.raises(CloudDensityExportError, match="time coordinate is empty"):
+        volume_cloud_density._resolve_time_index(  # noqa: SLF001
+            xr.Dataset(coords={"time": np.array([], dtype="datetime64[s]")}),
+            valid_time=None,
+        )
+
+    ds = xr.Dataset(
+        coords={
+            "time": np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]"),
+        }
+    )
+    with pytest.raises(CloudDensityExportError, match="valid_time not found"):
+        volume_cloud_density._resolve_time_index(ds, valid_time="2026-01-01T01:00:00Z")  # noqa: SLF001
+
+
+def test_volume_level_key_formats_and_errors() -> None:
+    assert volume_cloud_density._level_key("sfc") == "sfc"  # noqa: SLF001
+    assert volume_cloud_density._level_key(850.0) == "850"  # noqa: SLF001
+    assert volume_cloud_density._level_key(850.5) == "850.5"  # noqa: SLF001
+
+    with pytest.raises(CloudDensityExportError, match="non-finite"):
+        volume_cloud_density._level_key(np.nan)  # noqa: SLF001
+
+    with pytest.raises(ValueError, match="unsafe"):
+        volume_cloud_density._level_key("850/700")  # noqa: SLF001
+
+
+def test_volume_cli_exports_and_prints_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    ds = _rh_datacube_dataset(units="%")
+    input_path = tmp_path / "input.nc"
+    write_datacube(ds, input_path)
+
+    output_dir = tmp_path / "out"
+    rc = volume_main(
+        [
+            "--datacube",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--rh0",
+            "80",
+            "--rh1",
+            "100",
+            "--format",
+            "netcdf",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip() or "{}")
+    assert payload["layer"] == "ecmwf/cloud_density"
+    assert payload["rh0"] == pytest.approx(0.8)
+    assert payload["rh1"] == pytest.approx(1.0)
+    assert payload["levels"]
+    assert payload["files"]
+
+
+def test_volume_module_entrypoint_executes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ds = _rh_datacube_dataset(units="%")
+    input_path = tmp_path / "input.nc"
+    write_datacube(ds, input_path)
+
+    output_dir = tmp_path / "out_module"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "python -m volume",
+            "--datacube",
+            str(input_path),
+            "--output-dir",
+            str(output_dir),
+            "--rh0",
+            "80",
+            "--rh1",
+            "100",
+            "--format",
+            "netcdf",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_module("volume.__main__", run_name="__main__")
+    assert exc.value.code == 0


### PR DESCRIPTION
Closes #66

## Summary
- Derive `cloud_density` from RH via `smoothstep(RH0, RH1, RH)`
- Add configurable `pipeline.cloud_density_rh0`/`pipeline.cloud_density_rh1` (fraction or percent)
- Export per-level Volume API intermediate slices + optional manifest

## Testing
- `pytest packages/config/tests/ --cov=packages/config/src --cov-fail-under=90`
- `cd services/data-pipeline && PYTHONPATH=src:../../packages/config/src:../../packages/shared/src pytest tests/ --cov=src --cov-fail-under=90 -m "not integration"`
