### PR TITLE
[ST-0159] 点位仰视中的“飞行器”示例渲染（演示用）

### DIFF
--- a/apps/web/src/features/aircraft/AircraftDemoLayer.test.tsx
+++ b/apps/web/src/features/aircraft/AircraftDemoLayer.test.tsx
@@ -1,0 +1,209 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAircraftDemoStore } from '../../state/aircraftDemo';
+import { AircraftDemoLayer } from './AircraftDemoLayer';
+
+const cesiumMocks = vi.hoisted(() => {
+  return {
+    customDataSources: [] as Array<{
+      name: string;
+      show: boolean;
+      entities: { add: ReturnType<typeof vi.fn>; removeAll: ReturnType<typeof vi.fn> };
+    }>,
+    fromDegrees: vi.fn((lon: number, lat: number, height: number) => ({ lon, lat, height })),
+  };
+});
+
+vi.mock('cesium', () => {
+  return {
+    Cartesian3: {
+      fromDegrees: cesiumMocks.fromDegrees,
+    },
+    CustomDataSource: vi.fn(function (name: string) {
+      const instance = {
+        name,
+        show: true,
+        entities: {
+          add: vi.fn((entity: unknown) => entity),
+          removeAll: vi.fn(),
+        },
+      };
+      cesiumMocks.customDataSources.push(instance);
+      return instance;
+    }),
+    Entity: vi.fn(function (options: unknown) {
+      return { ...(options as Record<string, unknown>) };
+    }),
+  };
+});
+
+function createViewerStub() {
+  return {
+    dataSources: {
+      add: vi.fn(async (dataSource: unknown) => dataSource),
+      remove: vi.fn(() => true),
+    },
+    scene: {
+      requestRender: vi.fn(),
+    },
+  };
+}
+
+beforeEach(() => {
+  localStorage.removeItem('digital-earth.aircraftDemo');
+  useAircraftDemoStore.setState({ enabled: false });
+  cesiumMocks.customDataSources.length = 0;
+  cesiumMocks.fromDegrees.mockClear();
+});
+
+describe('AircraftDemoLayer', () => {
+  it('is lazy when disabled', async () => {
+    const viewer = createViewerStub();
+
+    render(
+      <AircraftDemoLayer
+        viewer={viewer as never}
+        viewModeRoute={{ viewModeId: 'local', lat: 30, lon: 120 }}
+        cameraPerspectiveId="upward"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(viewer.dataSources.add).not.toHaveBeenCalled();
+    });
+    expect(cesiumMocks.customDataSources).toHaveLength(0);
+  });
+
+  it('adds an aircraft data source in local mode when enabled', async () => {
+    const viewer = createViewerStub();
+
+    useAircraftDemoStore.getState().setEnabled(true);
+
+    render(
+      <AircraftDemoLayer
+        viewer={viewer as never}
+        viewModeRoute={{ viewModeId: 'local', lat: 30, lon: 120 }}
+        cameraPerspectiveId="upward"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(viewer.dataSources.add).toHaveBeenCalledTimes(1);
+    });
+
+    expect(cesiumMocks.customDataSources).toHaveLength(1);
+    const dataSource = cesiumMocks.customDataSources[0];
+    expect(dataSource.name).toBe('aircraft-demo');
+    expect(dataSource.show).toBe(true);
+    expect(dataSource.entities.removeAll).toHaveBeenCalledTimes(1);
+    expect(dataSource.entities.add).toHaveBeenCalled();
+
+    const heights = cesiumMocks.fromDegrees.mock.calls.map((call) => call[2]);
+    expect(heights.length).toBeGreaterThan(0);
+    for (const height of heights) {
+      expect(height).toBeGreaterThanOrEqual(9000);
+      expect(height).toBeLessThanOrEqual(12000);
+    }
+  });
+
+  it('hides aircraft when not in upward perspective', async () => {
+    const viewer = createViewerStub();
+    useAircraftDemoStore.getState().setEnabled(true);
+
+    render(
+      <AircraftDemoLayer
+        viewer={viewer as never}
+        viewModeRoute={{ viewModeId: 'local', lat: 30, lon: 120 }}
+        cameraPerspectiveId="forward"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(viewer.dataSources.add).toHaveBeenCalledTimes(1);
+    });
+
+    expect(cesiumMocks.customDataSources[0]?.show).toBe(false);
+  });
+
+  it('removes the data source when leaving local mode or disabling', async () => {
+    const viewer = createViewerStub();
+    useAircraftDemoStore.getState().setEnabled(true);
+
+    const { rerender } = render(
+      <AircraftDemoLayer
+        viewer={viewer as never}
+        viewModeRoute={{ viewModeId: 'local', lat: 30, lon: 120 }}
+        cameraPerspectiveId="upward"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(viewer.dataSources.add).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <AircraftDemoLayer
+        viewer={viewer as never}
+        viewModeRoute={{ viewModeId: 'global' }}
+        cameraPerspectiveId="upward"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(viewer.dataSources.remove).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <AircraftDemoLayer
+        viewer={viewer as never}
+        viewModeRoute={{ viewModeId: 'local', lat: 30, lon: 120 }}
+        cameraPerspectiveId="upward"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(viewer.dataSources.add).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      useAircraftDemoStore.getState().setEnabled(false);
+    });
+
+    await waitFor(() => {
+      expect(viewer.dataSources.remove).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('rebuilds aircraft positions when local origin changes', async () => {
+    const viewer = createViewerStub();
+    useAircraftDemoStore.getState().setEnabled(true);
+
+    const { rerender } = render(
+      <AircraftDemoLayer
+        viewer={viewer as never}
+        viewModeRoute={{ viewModeId: 'local', lat: 30, lon: 120 }}
+        cameraPerspectiveId="upward"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(viewer.dataSources.add).toHaveBeenCalledTimes(1);
+    });
+
+    const dataSource = cesiumMocks.customDataSources[0];
+    expect(dataSource.entities.removeAll).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <AircraftDemoLayer
+        viewer={viewer as never}
+        viewModeRoute={{ viewModeId: 'local', lat: 31, lon: 121 }}
+        cameraPerspectiveId="upward"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(dataSource.entities.removeAll).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/src/features/aircraft/AircraftDemoLayer.tsx
+++ b/apps/web/src/features/aircraft/AircraftDemoLayer.tsx
@@ -1,0 +1,135 @@
+import { Cartesian3, CustomDataSource, Entity, type Viewer } from 'cesium';
+import { useEffect, useRef } from 'react';
+
+import type { CameraPerspectiveId } from '../../state/cameraPerspective';
+import { useAircraftDemoStore } from '../../state/aircraftDemo';
+import type { ViewModeRoute } from '../../state/viewMode';
+
+type AircraftDemoLayerProps = {
+  viewer: Viewer;
+  viewModeRoute: ViewModeRoute;
+  cameraPerspectiveId: CameraPerspectiveId;
+};
+
+type AircraftDemoPoint = {
+  id: string;
+  eastMeters: number;
+  northMeters: number;
+  altitudeMeters: number;
+};
+
+const METERS_PER_DEGREE_LAT = 111_320;
+
+const AIRCRAFT_POINTS: AircraftDemoPoint[] = [
+  { id: 'alpha', eastMeters: 0, northMeters: 0, altitudeMeters: 10_000 },
+  { id: 'bravo', eastMeters: 4500, northMeters: 1500, altitudeMeters: 9_200 },
+  { id: 'charlie', eastMeters: -5200, northMeters: 2200, altitudeMeters: 9_800 },
+  { id: 'delta', eastMeters: 6800, northMeters: -3600, altitudeMeters: 10_600 },
+  { id: 'echo', eastMeters: -7200, northMeters: -2800, altitudeMeters: 11_200 },
+  { id: 'foxtrot', eastMeters: 10_500, northMeters: 4200, altitudeMeters: 9_600 },
+  { id: 'golf', eastMeters: -12_500, northMeters: 5200, altitudeMeters: 11_800 },
+  { id: 'hotel', eastMeters: 1800, northMeters: -11_200, altitudeMeters: 9_000 },
+];
+
+const AIRCRAFT_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24"><path fill="white" d="M2 16l8-2V5.5c0-.8.7-1.5 1.5-1.5S13 4.7 13 5.5V14l9 2v2l-9-1v3l2 1v1l-3-1-3 1v-1l2-1v-3l-8 1z"/></svg>`;
+
+const AIRCRAFT_ICON_URL = `data:image/svg+xml,${encodeURIComponent(AIRCRAFT_ICON_SVG)}`;
+
+function buildAircraftDemoPositions(origin: { lat: number; lon: number }) {
+  const latRad = (origin.lat * Math.PI) / 180;
+  const cosLat = Math.cos(latRad);
+  const lonScale = Math.abs(cosLat) < 1e-6 ? Number.POSITIVE_INFINITY : METERS_PER_DEGREE_LAT * cosLat;
+
+  return AIRCRAFT_POINTS.map((point) => {
+    const lat = origin.lat + point.northMeters / METERS_PER_DEGREE_LAT;
+    const lon = Number.isFinite(lonScale)
+      ? origin.lon + point.eastMeters / lonScale
+      : origin.lon;
+    return {
+      id: point.id,
+      lat,
+      lon,
+      altitudeMeters: point.altitudeMeters,
+    };
+  });
+}
+
+export function AircraftDemoLayer({
+  viewer,
+  viewModeRoute,
+  cameraPerspectiveId,
+}: AircraftDemoLayerProps) {
+  const enabled = useAircraftDemoStore((state) => state.enabled);
+  const dataSourceRef = useRef<CustomDataSource | null>(null);
+  const attachedViewerRef = useRef<Viewer | null>(null);
+  const lastKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const dataSource = dataSourceRef.current;
+    const attachedViewer = attachedViewerRef.current;
+
+    if (dataSource && attachedViewer && attachedViewer !== viewer) {
+      attachedViewer.dataSources.remove(dataSource, false);
+      attachedViewerRef.current = null;
+      lastKeyRef.current = null;
+    }
+
+    if (!enabled || viewModeRoute.viewModeId !== 'local') {
+      if (dataSource && attachedViewerRef.current === viewer) {
+        viewer.dataSources.remove(dataSource, false);
+        attachedViewerRef.current = null;
+        lastKeyRef.current = null;
+        viewer.scene.requestRender();
+      }
+      return;
+    }
+
+    const { lat, lon } = viewModeRoute;
+
+    const source = dataSourceRef.current ?? new CustomDataSource('aircraft-demo');
+    dataSourceRef.current = source;
+
+    if (attachedViewerRef.current !== viewer) {
+      void viewer.dataSources.add(source);
+      attachedViewerRef.current = viewer;
+    }
+
+    const nextShow = cameraPerspectiveId === 'upward';
+    if (source.show !== nextShow) source.show = nextShow;
+
+    const nextKey = `${lat}:${lon}`;
+    if (lastKeyRef.current !== nextKey) {
+      lastKeyRef.current = nextKey;
+      source.entities.removeAll();
+      const positions = buildAircraftDemoPositions({ lat, lon });
+      for (const position of positions) {
+        source.entities.add(
+          new Entity({
+            id: `aircraft-demo:${position.id}`,
+            position: Cartesian3.fromDegrees(position.lon, position.lat, position.altitudeMeters),
+            billboard: {
+              image: AIRCRAFT_ICON_URL,
+              scale: 0.9,
+              disableDepthTestDistance: Number.POSITIVE_INFINITY,
+            },
+          }),
+        );
+      }
+    }
+
+    viewer.scene.requestRender();
+  }, [cameraPerspectiveId, enabled, viewModeRoute, viewer]);
+
+  useEffect(() => {
+    return () => {
+      const dataSource = dataSourceRef.current;
+      const attachedViewer = attachedViewerRef.current;
+      if (!dataSource || !attachedViewer) return;
+      attachedViewer.dataSources.remove(dataSource, false);
+      attachedViewerRef.current = null;
+      lastKeyRef.current = null;
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/features/local/LocalInfoPanel.test.tsx
+++ b/apps/web/src/features/local/LocalInfoPanel.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+import { useAircraftDemoStore } from '../../state/aircraftDemo';
 import { DEFAULT_CAMERA_PERSPECTIVE_ID, useCameraPerspectiveStore } from '../../state/cameraPerspective';
 import { LocalInfoPanel } from './LocalInfoPanel';
 
@@ -9,6 +10,8 @@ describe('LocalInfoPanel', () => {
   it('renders location, height, time key, and active layer', () => {
     localStorage.removeItem('digital-earth.cameraPerspective');
     useCameraPerspectiveStore.setState({ cameraPerspectiveId: DEFAULT_CAMERA_PERSPECTIVE_ID });
+    localStorage.removeItem('digital-earth.aircraftDemo');
+    useAircraftDemoStore.setState({ enabled: false });
 
     render(
       <LocalInfoPanel
@@ -42,6 +45,8 @@ describe('LocalInfoPanel', () => {
 
     localStorage.removeItem('digital-earth.cameraPerspective');
     useCameraPerspectiveStore.setState({ cameraPerspectiveId: DEFAULT_CAMERA_PERSPECTIVE_ID });
+    localStorage.removeItem('digital-earth.aircraftDemo');
+    useAircraftDemoStore.setState({ enabled: false });
 
     render(
       <LocalInfoPanel
@@ -63,6 +68,8 @@ describe('LocalInfoPanel', () => {
   it('disables back button when canGoBack is false', () => {
     localStorage.removeItem('digital-earth.cameraPerspective');
     useCameraPerspectiveStore.setState({ cameraPerspectiveId: DEFAULT_CAMERA_PERSPECTIVE_ID });
+    localStorage.removeItem('digital-earth.aircraftDemo');
+    useAircraftDemoStore.setState({ enabled: false });
 
     render(
       <LocalInfoPanel
@@ -84,6 +91,8 @@ describe('LocalInfoPanel', () => {
 
     localStorage.removeItem('digital-earth.cameraPerspective');
     useCameraPerspectiveStore.setState({ cameraPerspectiveId: DEFAULT_CAMERA_PERSPECTIVE_ID });
+    localStorage.removeItem('digital-earth.aircraftDemo');
+    useAircraftDemoStore.setState({ enabled: false });
 
     render(
       <LocalInfoPanel
@@ -111,6 +120,8 @@ describe('LocalInfoPanel', () => {
   it('hides lock button when there is no active layer', () => {
     localStorage.removeItem('digital-earth.cameraPerspective');
     useCameraPerspectiveStore.setState({ cameraPerspectiveId: DEFAULT_CAMERA_PERSPECTIVE_ID });
+    localStorage.removeItem('digital-earth.aircraftDemo');
+    useAircraftDemoStore.setState({ enabled: false });
 
     render(
       <LocalInfoPanel
@@ -133,6 +144,8 @@ describe('LocalInfoPanel', () => {
 
     localStorage.removeItem('digital-earth.cameraPerspective');
     useCameraPerspectiveStore.setState({ cameraPerspectiveId: DEFAULT_CAMERA_PERSPECTIVE_ID });
+    localStorage.removeItem('digital-earth.aircraftDemo');
+    useAircraftDemoStore.setState({ enabled: false });
 
     render(
       <LocalInfoPanel
@@ -155,5 +168,32 @@ describe('LocalInfoPanel', () => {
 
     await user.click(screen.getByRole('button', { name: '锁定当前层' }));
     expect(onLockLayer).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles aircraft demo checkbox', async () => {
+    const user = userEvent.setup();
+
+    localStorage.removeItem('digital-earth.cameraPerspective');
+    useCameraPerspectiveStore.setState({ cameraPerspectiveId: DEFAULT_CAMERA_PERSPECTIVE_ID });
+    localStorage.removeItem('digital-earth.aircraftDemo');
+    useAircraftDemoStore.setState({ enabled: false });
+
+    render(
+      <LocalInfoPanel
+        lat={30}
+        lon={120}
+        timeKey={null}
+        activeLayer={null}
+        canGoBack={false}
+        onBack={() => {}}
+        onLockLayer={() => {}}
+      />,
+    );
+
+    const checkbox = screen.getByRole('checkbox', { name: '显示飞行器' });
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+    expect(useAircraftDemoStore.getState().enabled).toBe(true);
   });
 });

--- a/apps/web/src/features/local/LocalInfoPanel.tsx
+++ b/apps/web/src/features/local/LocalInfoPanel.tsx
@@ -1,4 +1,5 @@
 import type { LayerConfig } from '../../state/layerManager';
+import { useAircraftDemoStore } from '../../state/aircraftDemo';
 import { useCameraPerspectiveStore, type CameraPerspectiveId } from '../../state/cameraPerspective';
 
 const PERSPECTIVE_LABELS: Record<CameraPerspectiveId, string> = {
@@ -79,6 +80,8 @@ export function LocalInfoPanel({
   onBack,
   onLockLayer,
 }: LocalInfoPanelProps) {
+  const aircraftEnabled = useAircraftDemoStore((state) => state.enabled);
+  const setAircraftEnabled = useAircraftDemoStore((state) => state.setEnabled);
   const cameraPerspectiveId = useCameraPerspectiveStore((state) => state.cameraPerspectiveId);
   const setCameraPerspectiveId = useCameraPerspectiveStore((state) => state.setCameraPerspectiveId);
 
@@ -131,6 +134,20 @@ export function LocalInfoPanel({
             </button>
           ))}
         </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <div className="text-xs text-slate-400">演示</div>
+        <label className="flex items-center gap-2 text-xs text-slate-200">
+          <span className="select-none">飞行器</span>
+          <input
+            type="checkbox"
+            className="h-4 w-4 accent-blue-400"
+            checked={aircraftEnabled}
+            onChange={(event) => setAircraftEnabled(event.target.checked)}
+            aria-label="显示飞行器"
+          />
+        </label>
       </div>
 
       <dl className="mt-3 grid grid-cols-[1fr_auto] gap-x-3 gap-y-2 text-sm">

--- a/apps/web/src/features/viewer/CesiumViewer.test.tsx
+++ b/apps/web/src/features/viewer/CesiumViewer.test.tsx
@@ -432,6 +432,7 @@ import { DEFAULT_BASEMAP_ID } from '../../config/basemaps';
 import { clearProductsCache } from '../products/productsApi';
 import { clearCldasTileProbeCache } from '../layers/layersApi';
 import { useBasemapStore } from '../../state/basemap';
+import { useAircraftDemoStore } from '../../state/aircraftDemo';
 import { DEFAULT_CAMERA_PERSPECTIVE_ID, useCameraPerspectiveStore } from '../../state/cameraPerspective';
 import { useEventAutoLayersStore } from '../../state/eventAutoLayers';
 import { DEFAULT_EVENT_LAYER_MODE, useEventLayersStore } from '../../state/eventLayers';
@@ -471,7 +472,9 @@ describe('CesiumViewer', () => {
     localStorage.removeItem('digital-earth.viewMode');
     localStorage.removeItem('digital-earth.cameraPerspective');
     localStorage.removeItem('digital-earth.osmBuildings');
+    localStorage.removeItem('digital-earth.aircraftDemo');
     useBasemapStore.setState({ basemapId: DEFAULT_BASEMAP_ID });
+    useAircraftDemoStore.setState({ enabled: false });
     useCameraPerspectiveStore.setState({ cameraPerspectiveId: DEFAULT_CAMERA_PERSPECTIVE_ID });
     useEventAutoLayersStore.setState({ restoreOnExit: true, overrides: {} });
     useEventLayersStore.setState({ enabled: true, mode: DEFAULT_EVENT_LAYER_MODE });

--- a/apps/web/src/features/viewer/CesiumViewer.tsx
+++ b/apps/web/src/features/viewer/CesiumViewer.tsx
@@ -46,6 +46,7 @@ import { useSceneModeStore } from '../../state/sceneMode';
 import { useTimeStore } from '../../state/time';
 import { useViewerStatsStore } from '../../state/viewerStats';
 import { useViewModeStore, type ViewModeRoute } from '../../state/viewMode';
+import { AircraftDemoLayer } from '../aircraft/AircraftDemoLayer';
 import { PrecipitationParticles } from '../effects/PrecipitationParticles';
 import { DisasterDemo } from '../effects/DisasterDemo';
 import { WindArrows, windArrowDensityForCameraHeight } from '../effects/WindArrows';
@@ -3162,6 +3163,13 @@ export function CesiumViewer() {
     <div className="viewerRoot">
       <div ref={containerRef} className="viewerCanvas" data-testid="cesium-container" />
       <div id="effect-stage" className="absolute inset-0 z-0 pointer-events-none" />
+      {viewer ? (
+        <AircraftDemoLayer
+          viewer={viewer}
+          viewModeRoute={viewModeRoute}
+          cameraPerspectiveId={cameraPerspectiveId}
+        />
+      ) : null}
       <div className="viewerOverlay">
         {viewer ? <CompassControl viewer={viewer} /> : null}
         <SceneModeToggle />

--- a/apps/web/src/state/aircraftDemo.test.ts
+++ b/apps/web/src/state/aircraftDemo.test.ts
@@ -1,0 +1,74 @@
+import { act, render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'digital-earth.aircraftDemo';
+
+async function importFresh() {
+  vi.resetModules();
+  return await import('./aircraftDemo');
+}
+
+function writeStorage(value: unknown) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+}
+
+describe('aircraftDemo store', () => {
+  it('defaults to disabled when localStorage is empty', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { useAircraftDemoStore } = await importFresh();
+    expect(useAircraftDemoStore.getState().enabled).toBe(false);
+  });
+
+  it('restores a persisted enabled flag', async () => {
+    writeStorage({ enabled: true });
+    const { useAircraftDemoStore } = await importFresh();
+    expect(useAircraftDemoStore.getState().enabled).toBe(true);
+  });
+
+  it('falls back to disabled for invalid JSON', async () => {
+    localStorage.setItem(STORAGE_KEY, '{not-json');
+    const { useAircraftDemoStore } = await importFresh();
+    expect(useAircraftDemoStore.getState().enabled).toBe(false);
+  });
+
+  it('setEnabled updates state and persists', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { useAircraftDemoStore } = await importFresh();
+
+    useAircraftDemoStore.getState().setEnabled(true);
+    expect(useAircraftDemoStore.getState().enabled).toBe(true);
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
+    expect(persisted).toEqual({ enabled: true });
+  });
+
+  it('toggleEnabled flips enabled', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { useAircraftDemoStore } = await importFresh();
+
+    expect(useAircraftDemoStore.getState().enabled).toBe(false);
+    useAircraftDemoStore.getState().toggleEnabled();
+    expect(useAircraftDemoStore.getState().enabled).toBe(true);
+  });
+
+  it('useAircraftDemoStore subscribes via useSyncExternalStore', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { useAircraftDemoStore } = await importFresh();
+
+    function EnabledLabel() {
+      const enabled = useAircraftDemoStore((state) => state.enabled);
+      return createElement('div', { 'data-testid': 'enabled' }, String(enabled));
+    }
+
+    render(createElement(EnabledLabel));
+    expect(screen.getByTestId('enabled')).toHaveTextContent('false');
+
+    act(() => {
+      useAircraftDemoStore.getState().setEnabled(true);
+    });
+
+    expect(screen.getByTestId('enabled')).toHaveTextContent('true');
+  });
+});
+

--- a/apps/web/src/state/aircraftDemo.ts
+++ b/apps/web/src/state/aircraftDemo.ts
@@ -1,0 +1,91 @@
+import { useSyncExternalStore } from 'react';
+
+type AircraftDemoState = {
+  enabled: boolean;
+  setEnabled: (enabled: boolean) => void;
+  toggleEnabled: () => void;
+};
+
+const STORAGE_KEY = 'digital-earth.aircraftDemo';
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+function notify() {
+  for (const listener of listeners) listener();
+}
+
+function safeReadEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === 'boolean') return parsed;
+    if (!parsed || typeof parsed !== 'object') return false;
+    const record = parsed as Record<string, unknown>;
+    return typeof record.enabled === 'boolean' ? record.enabled : false;
+  } catch {
+    return false;
+  }
+}
+
+function safeWriteEnabled(nextEnabled: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ enabled: nextEnabled }));
+  } catch {
+    // ignore write failures (e.g., disabled storage)
+  }
+}
+
+let enabled = safeReadEnabled();
+
+const setEnabled: AircraftDemoState['setEnabled'] = (next) => {
+  if (Object.is(enabled, next)) return;
+  enabled = next;
+  safeWriteEnabled(next);
+  notify();
+};
+
+const toggleEnabled: AircraftDemoState['toggleEnabled'] = () => {
+  setEnabled(!enabled);
+};
+
+function getState(): AircraftDemoState {
+  return { enabled, setEnabled, toggleEnabled };
+}
+
+function setState(partial: Partial<Pick<AircraftDemoState, 'enabled'>>) {
+  if (typeof partial.enabled !== 'boolean') return;
+  enabled = partial.enabled;
+  safeWriteEnabled(partial.enabled);
+  notify();
+}
+
+function subscribe(listener: Listener) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+type Selector<T> = (state: AircraftDemoState) => T;
+
+type StoreHook = {
+  <T>(selector: Selector<T>): T;
+  getState: typeof getState;
+  setState: typeof setState;
+};
+
+const useAircraftDemoStoreImpl = <T>(selector: Selector<T>): T =>
+  useSyncExternalStore(
+    subscribe,
+    () => selector(getState()),
+    () => selector(getState()),
+  );
+
+export const useAircraftDemoStore: StoreHook = Object.assign(useAircraftDemoStoreImpl, {
+  getState,
+  setState,
+});
+


### PR DESCRIPTION
Closes #190

## Summary
- Add AircraftDemoLayer rendering lightweight aircraft billboards around 9–12km altitude in Local (upward) view
- Add Local panel toggle (persisted) to show/hide aircraft demo

## Testing
- pnpm test
- pnpm lint
- pnpm typecheck
