### PR TITLE
[ST-0140] Volume API：按 bbox/levels/res 生成云体数据

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install fastapi httpx pydantic pydantic-settings pytest pytest-cov pyyaml redis sqlalchemy alembic xarray h5netcdf h5py 'pillow>=10.0.0' zstandard numpy
+      - run: pip install 'fastapi==0.115.0' httpx 'pydantic==2.7.4' 'pydantic-settings==2.2.1' pytest pytest-cov pyyaml redis sqlalchemy alembic xarray h5netcdf h5py 'pillow>=10.0.0' zstandard numpy
       - run: |
           PYTHONPATH=apps/api/src:services/data-pipeline/src:packages/config/src:packages/shared/src pytest apps/api/tests/ \
             --cov=apps/api/src \

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install fastapi httpx pydantic pydantic-settings pytest pytest-cov pyyaml redis sqlalchemy alembic xarray h5netcdf h5py 'pillow>=10.0.0'
+      - run: pip install fastapi httpx pydantic pydantic-settings pytest pytest-cov pyyaml redis sqlalchemy alembic xarray h5netcdf h5py 'pillow>=10.0.0' zstandard numpy
       - run: |
           PYTHONPATH=apps/api/src:services/data-pipeline/src:packages/config/src:packages/shared/src pytest apps/api/tests/ \
             --cov=apps/api/src \

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -262,7 +262,11 @@
             "$ref": "#/components/schemas/ParticleSizeRange"
           },
           "risk_level": {
-            "$ref": "#/components/schemas/RiskLevel",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
             "readOnly": true
           },
           "spawn_rate": {
@@ -486,7 +490,6 @@
           "app_state": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -498,7 +501,6 @@
           "browser_info": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -812,7 +814,6 @@
             "type": "string"
           },
           "meta": {
-            "additionalProperties": true,
             "title": "Meta",
             "type": "object"
           },
@@ -1100,6 +1101,9 @@
           "type": {
             "const": "FeatureCollection",
             "default": "FeatureCollection",
+            "enum": [
+              "FeatureCollection"
+            ],
             "title": "Type",
             "type": "string"
           }
@@ -1123,6 +1127,9 @@
           "type": {
             "const": "Feature",
             "default": "Feature",
+            "enum": [
+              "Feature"
+            ],
             "title": "Type",
             "type": "string"
           }
@@ -1406,7 +1413,6 @@
             "type": "string"
           },
           "snapshot": {
-            "additionalProperties": true,
             "title": "Snapshot",
             "type": "object"
           },
@@ -1691,7 +1697,11 @@
         "additionalProperties": false,
         "properties": {
           "direction": {
-            "$ref": "#/components/schemas/ThresholdDirection",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ThresholdDirection"
+              }
+            ],
             "default": "ascending"
           },
           "id": {
@@ -2026,7 +2036,6 @@
         "additionalProperties": false,
         "properties": {
           "definition": {
-            "additionalProperties": true,
             "title": "Definition",
             "type": "object"
           },
@@ -3114,7 +3123,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "title": "Response Get Cldas Summary Api V1 Local Data Cldas Summary Get",
                   "type": "object"
                 }
@@ -3266,7 +3274,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "title": "Response Get Town Forecast Api V1 Local Data Town Forecast Get",
                   "type": "object"
                 }
@@ -4694,6 +4701,106 @@
         "summary": "Prewarm Ecmwf Wind Streamlines",
         "tags": [
           "vector"
+        ]
+      }
+    },
+    "/api/v1/volume": {
+      "get": {
+        "operationId": "get_volume_api_v1_volume_get",
+        "parameters": [
+          {
+            "description": "west,south,east,north,bottom,top (degrees/meters)",
+            "in": "query",
+            "name": "bbox",
+            "required": true,
+            "schema": {
+              "description": "west,south,east,north,bottom,top (degrees/meters)",
+              "examples": [
+                "-10,20,10,40,0,12000"
+              ],
+              "title": "Bbox",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated pressure levels (hPa)",
+            "in": "query",
+            "name": "levels",
+            "required": true,
+            "schema": {
+              "description": "Comma-separated pressure levels (hPa)",
+              "title": "Levels",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Horizontal resolution in meters",
+            "in": "query",
+            "name": "res",
+            "required": true,
+            "schema": {
+              "description": "Horizontal resolution in meters",
+              "title": "Res",
+              "type": "number"
+            }
+          },
+          {
+            "description": "ISO8601 timestamp",
+            "in": "query",
+            "name": "valid_time",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO8601 timestamp",
+              "title": "Valid Time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Volume Pack binary payload"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "503": {
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Get Volume",
+        "tags": [
+          "volume"
         ]
       }
     },

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -27,6 +27,7 @@ from routers.risk import router as risk_router
 from routers.tiles import router as tiles_router
 from routers.sample import router as sample_router
 from routers.vector import router as vector_router
+from routers.volume import router as volume_router
 
 
 def create_app() -> FastAPI:
@@ -86,6 +87,7 @@ def create_app() -> FastAPI:
     api_v1.include_router(products_router)
     api_v1.include_router(vector_router)
     api_v1.include_router(legends_router)
+    api_v1.include_router(volume_router)
     app.include_router(api_v1)
 
     return app

--- a/apps/api/src/routers/errors.py
+++ b/apps/api/src/routers/errors.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from fastapi import APIRouter, status
+from fastapi.responses import Response
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 logger = logging.getLogger("api.error")
@@ -62,8 +63,12 @@ class ErrorReport(BaseModel):
         return value.astimezone(timezone.utc)
 
 
-@router.post("/errors", status_code=status.HTTP_204_NO_CONTENT)
-def report_frontend_error(report: ErrorReport) -> None:
+@router.post(
+    "/errors",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def report_frontend_error(report: ErrorReport) -> Response:
     logger.error(
         "frontend.error_reported",
         extra={
@@ -72,3 +77,4 @@ def report_frontend_error(report: ErrorReport) -> None:
             "reported_at": _format_timestamp(report.timestamp),
         },
     )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/api/src/routers/volume.py
+++ b/apps/api/src/routers/volume.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from routes.volume import router
+

--- a/apps/api/src/routers/volume.py
+++ b/apps/api/src/routers/volume.py
@@ -2,3 +2,4 @@ from __future__ import annotations
 
 from routes.volume import router
 
+__all__ = ["router"]

--- a/apps/api/src/routes/__init__.py
+++ b/apps/api/src/routes/__init__.py
@@ -1,2 +1,1 @@
 from __future__ import annotations
-

--- a/apps/api/src/routes/__init__.py
+++ b/apps/api/src/routes/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+

--- a/apps/api/src/routes/volume.py
+++ b/apps/api/src/routes/volume.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import logging
+import math
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final
+
+import numpy as np
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import Response
+
+from datacube.storage import open_datacube
+from volume.cloud_density import DEFAULT_CLOUD_DENSITY_LAYER
+from volume.pack import encode_volume_pack
+
+logger = logging.getLogger("api.error")
+
+router = APIRouter(tags=["volume"])
+
+VOLUME_DATA_DIR_ENV: Final[str] = "DIGITAL_EARTH_VOLUME_DATA_DIR"
+
+MAX_BBOX_AREA_DEG2: Final[float] = 100.0
+MIN_RES_METERS: Final[float] = 100.0
+MAX_OUTPUT_BYTES: Final[int] = 64 * 1024 * 1024
+
+METERS_PER_DEG_LAT: Final[float] = 111_320.0
+
+_TIME_KEY_FORMAT: Final[str] = "%Y%m%dT%H%M%SZ"
+_ISO_Z_FORMAT: Final[str] = "%Y-%m-%dT%H:%M:%SZ"
+
+
+@dataclass(frozen=True)
+class BBox:
+    west: float
+    south: float
+    east: float
+    north: float
+    bottom: float
+    top: float
+
+    def area_deg2(self) -> float:
+        return (self.east - self.west) * (self.north - self.south)
+
+    def to_header(self) -> dict[str, float]:
+        return {
+            "west": float(self.west),
+            "south": float(self.south),
+            "east": float(self.east),
+            "north": float(self.north),
+            "bottom": float(self.bottom),
+            "top": float(self.top),
+        }
+
+
+def _parse_bbox(value: str) -> BBox:
+    raw = (value or "").strip()
+    if raw == "":
+        raise ValueError("bbox must not be empty")
+
+    parts = [part.strip() for part in raw.split(",")]
+    if len(parts) != 6:
+        raise ValueError("bbox must have 6 comma-separated numbers")
+
+    try:
+        west, south, east, north, bottom, top = (float(part) for part in parts)
+    except ValueError as exc:
+        raise ValueError("bbox values must be valid numbers") from exc
+
+    floats = (west, south, east, north, bottom, top)
+    if not all(math.isfinite(item) for item in floats):
+        raise ValueError("bbox values must be finite numbers")
+
+    if east <= west:
+        raise ValueError("bbox east must be > west")
+    if north <= south:
+        raise ValueError("bbox north must be > south")
+
+    bbox = BBox(
+        west=float(west),
+        south=float(south),
+        east=float(east),
+        north=float(north),
+        bottom=float(bottom),
+        top=float(top),
+    )
+    if bbox.area_deg2() > MAX_BBOX_AREA_DEG2:
+        raise ValueError("bbox area exceeds maximum")
+    return bbox
+
+
+def _parse_levels(value: str) -> tuple[str, ...]:
+    raw = (value or "").strip()
+    if raw == "":
+        raise ValueError("levels must not be empty")
+
+    items = [part.strip() for part in raw.split(",") if part.strip()]
+    if not items:
+        raise ValueError("levels must not be empty")
+
+    normalized: list[str] = []
+    for item in items:
+        try:
+            numeric = float(item)
+        except ValueError as exc:
+            raise ValueError("levels must be comma-separated numbers") from exc
+        if not math.isfinite(numeric):
+            raise ValueError("levels must be finite numbers")
+        if abs(numeric - round(numeric)) < 1e-6:
+            normalized.append(str(int(round(numeric))))
+        else:
+            normalized.append(str(float(numeric)))
+
+    deduped = list(dict.fromkeys(normalized))
+    return tuple(deduped)
+
+
+def _parse_valid_time(value: str) -> datetime:
+    raw = (value or "").strip()
+    if raw == "":
+        raise ValueError("valid_time must not be empty")
+
+    candidate = raw
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise ValueError("valid_time must be an ISO8601 timestamp") from exc
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0)
+
+
+def _time_key(dt: datetime) -> str:
+    parsed = dt
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).strftime(_TIME_KEY_FORMAT)
+
+
+def _iso_z(dt: datetime) -> str:
+    parsed = dt
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).strftime(_ISO_Z_FORMAT)
+
+
+def _parse_time_key(value: str) -> datetime | None:
+    try:
+        parsed = datetime.strptime(value, _TIME_KEY_FORMAT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+    return parsed
+
+
+def _resolve_volume_base_dir() -> Path:
+    raw = os.environ.get(VOLUME_DATA_DIR_ENV, "").strip()
+    if raw == "":
+        raise HTTPException(
+            status_code=503,
+            detail=f"Volume data directory is not configured ({VOLUME_DATA_DIR_ENV})",
+        )
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Volume data directory not found")
+    if not path.is_dir():
+        raise HTTPException(status_code=400, detail="Volume data path is not a directory")
+    return path
+
+
+def _resolve_time_dir(
+    base_dir: Path, *, layer: str, valid_time: datetime | None
+) -> tuple[str, datetime, Path]:
+    layer_dir = (base_dir / layer).resolve()
+    if not layer_dir.exists() or not layer_dir.is_dir():
+        raise HTTPException(status_code=404, detail="Volume layer not found")
+
+    if valid_time is not None:
+        key = _time_key(valid_time)
+        target = layer_dir / key
+        if not target.exists() or not target.is_dir():
+            raise HTTPException(status_code=404, detail="valid_time not found")
+        return key, valid_time, target
+
+    candidates: list[tuple[str, datetime]] = []
+    for entry in layer_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        dt = _parse_time_key(entry.name)
+        if dt is None:
+            continue
+        candidates.append((entry.name, dt))
+    if not candidates:
+        raise HTTPException(status_code=404, detail="No volume times available")
+
+    key, dt = max(candidates, key=lambda item: item[0])
+    return key, dt, layer_dir / key
+
+
+def _resolve_slice_path(time_dir: Path, *, level_key: str) -> Path:
+    netcdf_path = time_dir / f"{level_key}.nc"
+    if netcdf_path.is_file():
+        return netcdf_path
+    zarr_path = time_dir / f"{level_key}.zarr"
+    if zarr_path.exists() and zarr_path.is_dir():
+        return zarr_path
+    raise HTTPException(status_code=404, detail=f"level not found: {level_key}")
+
+
+def _normalize_lon(value: float, lon_coord: np.ndarray) -> float:
+    coord = np.asarray(lon_coord, dtype=np.float64)
+    if coord.size == 0:
+        return float(value)
+    lon_min = float(np.nanmin(coord))
+    lon_max = float(np.nanmax(coord))
+
+    lon = float(value)
+    if lon_min >= 0.0 and lon_max > 180.0:
+        return lon % 360.0
+    return ((lon + 180.0) % 360.0) - 180.0
+
+
+def _monotonic_1d(coord: np.ndarray) -> bool:
+    if coord.ndim != 1:
+        return False
+    if coord.size < 2:
+        return True
+    diffs = np.diff(coord.astype(np.float64, copy=False))
+    return bool(np.all(diffs > 0) or np.all(diffs < 0))
+
+
+def _sorted_axis(coord: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    order = np.argsort(coord.astype(np.float64, copy=False))
+    return coord[order], order
+
+
+def _bounding_slice(coord_sorted: np.ndarray, vmin: float, vmax: float) -> slice:
+    if coord_sorted.size == 0:
+        return slice(0, 0)
+    start = max(0, int(np.searchsorted(coord_sorted, vmin, side="left")) - 1)
+    end = min(
+        int(coord_sorted.size - 1),
+        int(np.searchsorted(coord_sorted, vmax, side="right")),
+    )
+    if end < start:
+        return slice(0, 0)
+    return slice(start, end + 1)
+
+
+def _interp_1d(x: np.ndarray, y: np.ndarray, x_new: np.ndarray) -> np.ndarray:
+    x_f = np.asarray(x, dtype=np.float64)
+    y_f = np.asarray(y, dtype=np.float32)
+    xq = np.asarray(x_new, dtype=np.float64)
+    if x_f.size == 0:
+        raise ValueError("source coordinate is empty")
+    if x_f.size == 1:
+        return np.full(xq.shape, float(y_f[0]), dtype=np.float32)
+    return np.interp(xq, x_f, y_f).astype(np.float32, copy=False)
+
+
+def _interp2d(
+    *,
+    lat: np.ndarray,
+    lon: np.ndarray,
+    values: np.ndarray,
+    target_lat: np.ndarray,
+    target_lon: np.ndarray,
+) -> np.ndarray:
+    if lat.ndim != 1 or lon.ndim != 1:
+        raise ValueError("lat/lon must be 1D coordinates")
+    if values.shape != (lat.size, lon.size):
+        raise ValueError("values must have shape (lat, lon)")
+
+    lon_intermediate = np.empty((lat.size, target_lon.size), dtype=np.float32)
+    for i in range(lat.size):
+        lon_intermediate[i, :] = _interp_1d(lon, values[i, :], target_lon)
+
+    out = np.empty((target_lat.size, target_lon.size), dtype=np.float32)
+    for j in range(target_lon.size):
+        out[:, j] = _interp_1d(lat, lon_intermediate[:, j], target_lat)
+
+    return out
+
+
+def _read_cloud_density_grid(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ds = open_datacube(path)
+    try:
+        if "cloud_density" not in ds.data_vars:
+            raise HTTPException(status_code=500, detail="Slice missing cloud_density")
+        da = ds["cloud_density"].squeeze(drop=True)
+        if set(da.dims) != {"lat", "lon"}:
+            raise HTTPException(
+                status_code=500, detail="Slice must have lat/lon dimensions"
+            )
+        lat = np.asarray(da["lat"].values, dtype=np.float64)
+        lon = np.asarray(da["lon"].values, dtype=np.float64)
+        values = np.asarray(da.values, dtype=np.float32)
+    finally:
+        ds.close()
+
+    if not (_monotonic_1d(lat) and _monotonic_1d(lon)):
+        raise HTTPException(status_code=500, detail="Slice coordinates are not monotonic")
+    if values.ndim != 2 or values.shape != (lat.size, lon.size):
+        raise HTTPException(status_code=500, detail="Slice has invalid data shape")
+    return lat, lon, values
+
+
+def _target_grid(bbox: BBox, *, res_m: float) -> tuple[np.ndarray, np.ndarray]:
+    lat_dist_m = (bbox.north - bbox.south) * METERS_PER_DEG_LAT
+    mean_lat_rad = math.radians((bbox.south + bbox.north) / 2.0)
+    lon_dist_m = (
+        (bbox.east - bbox.west)
+        * METERS_PER_DEG_LAT
+        * max(0.0, abs(math.cos(mean_lat_rad)))
+    )
+
+    n_lat = max(2, int(math.ceil(lat_dist_m / res_m)) + 1)
+    n_lon = max(2, int(math.ceil(lon_dist_m / res_m)) + 1)
+
+    target_lat = np.linspace(bbox.south, bbox.north, n_lat, dtype=np.float64)
+    target_lon = np.linspace(bbox.west, bbox.east, n_lon, dtype=np.float64)
+    return target_lat, target_lon
+
+
+@router.get(
+    "/volume",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Volume Pack binary payload",
+            "content": {
+                "application/octet-stream": {
+                    "schema": {"type": "string", "format": "binary"}
+                }
+            },
+        },
+        400: {"description": "Bad Request"},
+        404: {"description": "Not Found"},
+        500: {"description": "Internal Server Error"},
+        503: {"description": "Service Unavailable"},
+    },
+)
+def get_volume(
+    bbox: str = Query(
+        ...,
+        description="west,south,east,north,bottom,top (degrees/meters)",
+        examples=["-10,20,10,40,0,12000"],
+    ),
+    levels: str = Query(..., description="Comma-separated pressure levels (hPa)"),
+    res: float = Query(..., description="Horizontal resolution in meters"),
+    valid_time: str | None = Query(default=None, description="ISO8601 timestamp"),
+) -> Response:
+    try:
+        bbox_parsed = _parse_bbox(bbox)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        levels_keys = _parse_levels(levels)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        res_m = float(res)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="res must be a number") from exc
+    if not math.isfinite(res_m) or res_m <= 0:
+        raise HTTPException(status_code=400, detail="res must be a positive number")
+    if res_m < MIN_RES_METERS:
+        raise HTTPException(status_code=400, detail="res is below minimum")
+
+    dt: datetime | None = None
+    if valid_time is not None:
+        try:
+            dt = _parse_valid_time(valid_time)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    target_lat, target_lon = _target_grid(bbox_parsed, res_m=res_m)
+    decoded_bytes = int(len(levels_keys)) * int(target_lat.size) * int(target_lon.size) * 4
+    if decoded_bytes > MAX_OUTPUT_BYTES:
+        raise HTTPException(status_code=400, detail="Requested volume exceeds max size")
+
+    base_dir = _resolve_volume_base_dir()
+    _time_key, resolved_dt, time_dir = _resolve_time_dir(
+        base_dir, layer=DEFAULT_CLOUD_DENSITY_LAYER, valid_time=dt
+    )
+
+    slices: list[np.ndarray] = []
+    lon_coord: np.ndarray | None = None
+    lat_coord: np.ndarray | None = None
+    for level_key in levels_keys:
+        slice_path = _resolve_slice_path(time_dir, level_key=level_key)
+        lat, lon, values = _read_cloud_density_grid(slice_path)
+
+        lon_w = _normalize_lon(bbox_parsed.west, lon)
+        lon_e = _normalize_lon(bbox_parsed.east, lon)
+        if lon_e <= lon_w:
+            raise HTTPException(status_code=400, detail="bbox crosses longitude seam")
+
+        lon_sorted, lon_order = _sorted_axis(lon)
+        lat_sorted, lat_order = _sorted_axis(lat)
+        values_sorted = values[np.ix_(lat_order, lon_order)]
+
+        lat_slice = _bounding_slice(lat_sorted, bbox_parsed.south, bbox_parsed.north)
+        lon_slice = _bounding_slice(lon_sorted, lon_w, lon_e)
+        if lat_slice.stop == 0 or lon_slice.stop == 0:
+            raise HTTPException(status_code=404, detail="bbox outside dataset")
+
+        lat_sub = lat_sorted[lat_slice]
+        lon_sub = lon_sorted[lon_slice]
+        values_sub = values_sorted[lat_slice, :][:, lon_slice]
+
+        if lat_coord is None:
+            lat_coord = lat_sub
+            lon_coord = lon_sub
+        else:
+            if lat_coord.shape != lat_sub.shape or lon_coord is None or lon_coord.shape != lon_sub.shape:
+                raise HTTPException(status_code=500, detail="Slice grids do not match")
+
+        target_lon_norm = np.linspace(lon_w, lon_e, target_lon.size, dtype=np.float64)
+        slice_resampled = _interp2d(
+            lat=lat_sub,
+            lon=lon_sub,
+            values=values_sub,
+            target_lat=target_lat,
+            target_lon=target_lon_norm,
+        )
+        slices.append(slice_resampled)
+
+    volume = np.stack(slices, axis=0).astype(np.float32, copy=False)
+
+    header = {
+        "bbox": bbox_parsed.to_header(),
+        "levels": [int(level) if level.isdigit() else float(level) for level in levels_keys],
+        "variable": "cloud_density",
+        "valid_time": _iso_z(resolved_dt),
+        "res_m": float(res_m),
+        "layer": DEFAULT_CLOUD_DENSITY_LAYER,
+        "scale": 1.0,
+        "offset": 0.0,
+        "dtype": "float32",
+    }
+
+    try:
+        payload = encode_volume_pack(volume, header=header, compression_level=3)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("volume_encode_error", extra={"error": str(exc)})
+        raise HTTPException(status_code=500, detail="Failed to encode volume") from exc
+
+    if len(payload) > MAX_OUTPUT_BYTES:
+        raise HTTPException(status_code=400, detail="Encoded volume exceeds max size")
+
+    return Response(content=payload, media_type="application/octet-stream")
+

--- a/apps/api/src/routes/volume.py
+++ b/apps/api/src/routes/volume.py
@@ -171,7 +171,9 @@ def _resolve_volume_base_dir() -> Path:
     if not path.exists():
         raise HTTPException(status_code=404, detail="Volume data directory not found")
     if not path.is_dir():
-        raise HTTPException(status_code=400, detail="Volume data path is not a directory")
+        raise HTTPException(
+            status_code=400, detail="Volume data path is not a directory"
+        )
     return path
 
 
@@ -306,7 +308,9 @@ def _read_cloud_density_grid(path: Path) -> tuple[np.ndarray, np.ndarray, np.nda
         ds.close()
 
     if not (_monotonic_1d(lat) and _monotonic_1d(lon)):
-        raise HTTPException(status_code=500, detail="Slice coordinates are not monotonic")
+        raise HTTPException(
+            status_code=500, detail="Slice coordinates are not monotonic"
+        )
     if values.ndim != 2 or values.shape != (lat.size, lon.size):
         raise HTTPException(status_code=500, detail="Slice has invalid data shape")
     return lat, lon, values
@@ -384,7 +388,9 @@ def get_volume(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     target_lat, target_lon = _target_grid(bbox_parsed, res_m=res_m)
-    decoded_bytes = int(len(levels_keys)) * int(target_lat.size) * int(target_lon.size) * 4
+    decoded_bytes = (
+        int(len(levels_keys)) * int(target_lat.size) * int(target_lon.size) * 4
+    )
     if decoded_bytes > MAX_OUTPUT_BYTES:
         raise HTTPException(status_code=400, detail="Requested volume exceeds max size")
 
@@ -422,7 +428,11 @@ def get_volume(
             lat_coord = lat_sub
             lon_coord = lon_sub
         else:
-            if lat_coord.shape != lat_sub.shape or lon_coord is None or lon_coord.shape != lon_sub.shape:
+            if (
+                lat_coord.shape != lat_sub.shape
+                or lon_coord is None
+                or lon_coord.shape != lon_sub.shape
+            ):
                 raise HTTPException(status_code=500, detail="Slice grids do not match")
 
         target_lon_norm = np.linspace(lon_w, lon_e, target_lon.size, dtype=np.float64)
@@ -439,7 +449,9 @@ def get_volume(
 
     header = {
         "bbox": bbox_parsed.to_header(),
-        "levels": [int(level) if level.isdigit() else float(level) for level in levels_keys],
+        "levels": [
+            int(level) if level.isdigit() else float(level) for level in levels_keys
+        ],
         "variable": "cloud_density",
         "valid_time": _iso_z(resolved_dt),
         "res_m": float(res_m),
@@ -459,4 +471,3 @@ def get_volume(
         raise HTTPException(status_code=400, detail="Encoded volume exceeds max size")
 
     return Response(content=payload, media_type="application/octet-stream")
-

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -50,7 +50,9 @@ def _patch_testclient_client_kw() -> None:
             return
 
         transport = getattr(self, "_transport", None)
-        original_app = getattr(transport, "app", None) if transport is not None else None
+        original_app = (
+            getattr(transport, "app", None) if transport is not None else None
+        )
         if original_app is None:
             return
 

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,5 +1,7 @@
 import sys
 from pathlib import Path
+import inspect
+from typing import Any
 
 API_SRC = Path(__file__).resolve().parents[1] / "src"
 TESTS_SRC = Path(__file__).resolve().parent
@@ -14,3 +16,52 @@ sys.path.insert(0, str(CONFIG_SRC))
 sys.path.insert(0, str(PIPELINE_SRC))
 sys.path.insert(0, str(API_SRC))
 sys.path.insert(0, str(TESTS_SRC))
+
+
+def _patch_testclient_client_kw() -> None:
+    try:
+        from starlette.testclient import TestClient as StarletteTestClient
+    except Exception:
+        return
+
+    try:
+        sig = inspect.signature(StarletteTestClient.__init__)
+    except (TypeError, ValueError):
+        return
+
+    if "client" in sig.parameters:
+        return
+
+    original_init = StarletteTestClient.__init__
+
+    def patched_init(self: Any, *args: Any, client: Any = None, **kwargs: Any) -> None:
+        if "client" in kwargs:
+            client = kwargs.pop("client")
+
+        original_init(self, *args, **kwargs)
+
+        if client is None:
+            return
+
+        try:
+            host, port = client
+            client_value = [str(host), int(port)]
+        except Exception:
+            return
+
+        transport = getattr(self, "_transport", None)
+        original_app = getattr(transport, "app", None) if transport is not None else None
+        if original_app is None:
+            return
+
+        async def app_with_client(scope: Any, receive: Any, send: Any) -> None:
+            if isinstance(scope, dict):
+                scope["client"] = client_value
+            await original_app(scope, receive, send)
+
+        transport.app = app_with_client
+
+    StarletteTestClient.__init__ = patched_init  # type: ignore[assignment]
+
+
+_patch_testclient_client_kw()

--- a/apps/api/tests/test_volume_api.py
+++ b/apps/api/tests/test_volume_api.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+from fastapi.testclient import TestClient
+
+from volume.cloud_density import DEFAULT_CLOUD_DENSITY_LAYER
+from volume.pack import decode_volume_pack
+
+
+def _write_config(dir_path: Path, env: str, data: dict) -> None:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / f"{env}.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _base_config() -> dict:
+    return {
+        "api": {
+            "host": "0.0.0.0",
+            "port": 8000,
+            "debug": True,
+            "cors_origins": [],
+            "rate_limit": {"enabled": False},
+        },
+        "pipeline": {"workers": 2, "batch_size": 100},
+        "web": {"api_base_url": "http://localhost:8000"},
+        "database": {"host": "localhost", "port": 5432, "name": "digital_earth"},
+        "redis": {"host": "localhost", "port": 6379},
+        "storage": {"tiles_bucket": "tiles", "raw_bucket": "raw"},
+    }
+
+
+def _make_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    volume_data_dir: Path | None = None,
+) -> TestClient:
+    config_dir = tmp_path / "config"
+    _write_config(config_dir, "dev", _base_config())
+
+    monkeypatch.setenv("DIGITAL_EARTH_ENV", "dev")
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("DIGITAL_EARTH_DB_USER", "app")
+    monkeypatch.setenv("DIGITAL_EARTH_DB_PASSWORD", "secret")
+
+    if volume_data_dir is not None:
+        monkeypatch.setenv("DIGITAL_EARTH_VOLUME_DATA_DIR", str(volume_data_dir))
+    else:
+        monkeypatch.delenv("DIGITAL_EARTH_VOLUME_DATA_DIR", raising=False)
+
+    from config import get_settings
+    from main import create_app
+
+    get_settings.cache_clear()
+    return TestClient(create_app())
+
+
+def _write_cloud_density_slice(
+    path: Path,
+    *,
+    valid_time: str,
+    level: int,
+    lat: list[float],
+    lon: list[float],
+    values: np.ndarray,
+) -> None:
+    data = values.astype(np.float32, copy=False).reshape((1, 1, len(lat), len(lon)))
+    ds = xr.Dataset(
+        {
+            "cloud_density": (("time", "level", "lat", "lon"), data),
+        },
+        coords={
+            "time": [np.datetime64(valid_time)],
+            "level": [float(level)],
+            "lat": np.asarray(lat, dtype=np.float64),
+            "lon": np.asarray(lon, dtype=np.float64),
+        },
+        attrs={"schema": "digital-earth.volume-slice", "schema_version": 1},
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path, engine="h5netcdf")
+
+
+def test_volume_rejects_bbox_area_over_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    client = _make_client(monkeypatch, tmp_path)
+    response = client.get(
+        "/api/v1/volume",
+        params={
+            "bbox": "0,0,20,20,0,1",
+            "levels": "300,500",
+            "res": "1000",
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_volume_rejects_res_below_minimum(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    client = _make_client(monkeypatch, tmp_path)
+    response = client.get(
+        "/api/v1/volume",
+        params={
+            "bbox": "0,0,0.1,0.1,0,1",
+            "levels": "300,500",
+            "res": "10",
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_volume_rejects_output_size_over_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    client = _make_client(monkeypatch, tmp_path)
+    response = client.get(
+        "/api/v1/volume",
+        params={
+            "bbox": "0,0,2,2,0,1",
+            "levels": "300,400,500,600",
+            "res": "100",
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_volume_returns_volume_pack_for_cloud_density_slices(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    base_dir = tmp_path / "volume-data"
+    time_key = "20260101T000000Z"
+    valid_time = "2026-01-01T00:00:00"
+
+    time_dir = base_dir / DEFAULT_CLOUD_DENSITY_LAYER / time_key
+    lat = [0.0, 0.1, 0.2]
+    lon = [0.0, 0.1, 0.2]
+
+    values_300 = np.arange(9, dtype=np.float32).reshape((3, 3))
+    values_500 = values_300 + 100.0
+    _write_cloud_density_slice(
+        time_dir / "300.nc",
+        valid_time=valid_time,
+        level=300,
+        lat=lat,
+        lon=lon,
+        values=values_300,
+    )
+    _write_cloud_density_slice(
+        time_dir / "500.nc",
+        valid_time=valid_time,
+        level=500,
+        lat=lat,
+        lon=lon,
+        values=values_500,
+    )
+
+    client = _make_client(monkeypatch, tmp_path, volume_data_dir=base_dir)
+    response = client.get(
+        "/api/v1/volume",
+        params={
+            "bbox": "0,0,0.2,0.2,0,12000",
+            "levels": "300,500",
+            "res": "11132",
+            "valid_time": "2026-01-01T00:00:00Z",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/octet-stream")
+    assert response.content[:4] == b"VOLP"
+
+    header, array = decode_volume_pack(response.content)
+    assert header["shape"] == [2, 3, 3]
+    assert header["dtype"] == "float32"
+    assert header["variable"] == "cloud_density"
+    assert header["levels"] == [300, 500]
+    assert header["bbox"]["west"] == 0.0
+    assert header["bbox"]["east"] == 0.2
+    assert header["valid_time"] == "2026-01-01T00:00:00Z"
+
+    assert array.shape == (2, 3, 3)
+    assert np.allclose(array[0], values_300)
+    assert np.allclose(array[1], values_500)
+

--- a/apps/api/tests/test_volume_api.py
+++ b/apps/api/tests/test_volume_api.py
@@ -187,4 +187,3 @@ def test_volume_returns_volume_pack_for_cloud_density_slices(
     assert array.shape == (2, 3, 3)
     assert np.allclose(array[0], values_300)
     assert np.allclose(array[1], values_500)
-


### PR DESCRIPTION
## Summary
Implements #171 - Volume API for cloud body data generation

## Changes
- `apps/api/src/routes/volume.py` - GET /api/v1/volume endpoint
- `apps/api/src/routers/volume.py` - Router wrapper
- `apps/api/src/main.py` - Wire volume router
- `apps/api/tests/test_volume_api.py` - Endpoint tests
- `apps/api/tests/conftest.py` - TestClient compatibility shim
- `apps/api/openapi.json` - Updated OpenAPI snapshot

## Features
- Load cloud_density slice files from intermediate storage
- Crop by bbox parameter (west,south,east,north,bottom,top)
- Resample to specified resolution (res in meters)
- Return Volume Pack (VOLP) binary format
- Support valid_time parameter (falls back to latest)

## Limits (returns 400 if exceeded)
- bbox area <= 100 deg²
- res >= 100m
- output <= 64MB

## Testing
- Unit tests for validation (bbox, res limits)
- Integration test with mock slice files
- VOLP decoding verification

Closes #171