### PR TITLE
fix(api): prevent DoS in Volume API (#171 post-merge)

### DIFF
--- a/apps/api/tests/test_volume_api.py
+++ b/apps/api/tests/test_volume_api.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
 import pytest
 import xarray as xr
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from volume.cloud_density import DEFAULT_CLOUD_DENSITY_LAYER
 from volume.pack import decode_volume_pack
+from routes import volume as volume_routes
 
 
 def _write_config(dir_path: Path, env: str, data: dict) -> None:
@@ -336,5 +339,369 @@ def test_volume_returns_400_for_non_finite_res(
     response = client.get(
         "/api/v1/volume",
         params={"bbox": "0,0,0.1,0.1,0,1", "levels": "300", "res": "inf"},
+    )
+    assert response.status_code == 400
+
+
+def test_estimate_grid_size_rejects_non_finite_grid() -> None:
+    bbox = volume_routes.BBox(
+        west=0.0,
+        south=float("nan"),
+        east=1.0,
+        north=1.0,
+        bottom=0.0,
+        top=1.0,
+    )
+    with pytest.raises(ValueError, match="finite grid size"):
+        volume_routes._estimate_grid_size(bbox, res_m=1000.0)
+
+
+def test_estimate_grid_size_handles_overflow_error() -> None:
+    bbox = volume_routes.BBox(
+        west=0.0,
+        south=0.0,
+        east=0.1,
+        north=0.1,
+        bottom=0.0,
+        top=1.0,
+    )
+    with pytest.raises(ValueError, match="finite grid size"):
+        volume_routes._estimate_grid_size(bbox, res_m=1e-323)
+
+
+def test_bounding_slice_monotonic_handles_empty_and_single_coord() -> None:
+    assert volume_routes._bounding_slice_monotonic(np.array([]), 0.0, 1.0) == slice(
+        0, 0
+    )
+    assert volume_routes._bounding_slice_monotonic(np.array([42.0]), 0.0, 1.0) == slice(
+        0, 1
+    )
+
+
+def test_bounding_slice_monotonic_handles_descending_coords() -> None:
+    coord = np.array([3.0, 2.0, 1.0, 0.0])
+    assert volume_routes._bounding_slice_monotonic(coord, 0.5, 1.5) == slice(1, 4)
+    assert volume_routes._bounding_slice_monotonic(coord, 2.0, -1.0) == slice(0, 0)
+
+
+def test_read_cloud_density_coords_raises_when_missing_cloud_density_var(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "missing-var.nc"
+    ds = xr.Dataset(
+        {"temperature": (("lat", "lon"), np.zeros((2, 2), dtype=np.float32))},
+        coords={"lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    ds.to_netcdf(path, engine="h5netcdf")
+
+    with pytest.raises(HTTPException) as excinfo:
+        volume_routes._read_cloud_density_coords(path)
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Slice missing cloud_density"
+
+
+def test_read_cloud_density_coords_raises_when_dims_not_lat_lon(tmp_path: Path) -> None:
+    path = tmp_path / "wrong-dims.nc"
+    ds = xr.Dataset(
+        {
+            "cloud_density": (
+                ("time", "lat", "lon"),
+                np.zeros((2, 2, 2), dtype=np.float32),
+            )
+        },
+        coords={
+            "time": [np.datetime64("2026-01-01"), np.datetime64("2026-01-02")],
+            "lat": [0.0, 1.0],
+            "lon": [0.0, 1.0],
+        },
+    )
+    ds.to_netcdf(path, engine="h5netcdf")
+
+    with pytest.raises(HTTPException) as excinfo:
+        volume_routes._read_cloud_density_coords(path)
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Slice must have lat/lon dimensions"
+
+
+def test_read_cloud_density_coords_raises_when_coords_non_monotonic(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "non-monotonic-coords.nc"
+    lat = [0.0, 0.2, 0.1]
+    lon = [0.0, 0.1, 0.2]
+    values = np.ones((len(lat), len(lon)), dtype=np.float32)
+    _write_cloud_density_slice(
+        path,
+        valid_time="2026-01-01T00:00:00",
+        level=300,
+        lat=lat,
+        lon=lon,
+        values=values,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        volume_routes._read_cloud_density_coords(path)
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Slice coordinates are not monotonic"
+
+
+def test_read_cloud_density_grid_subsets_using_lat_lon_bounds(tmp_path: Path) -> None:
+    path = tmp_path / "subset.nc"
+    lat = [0.0, 1.0, 2.0, 3.0, 4.0]
+    lon = [10.0, 11.0, 12.0, 13.0, 14.0]
+    values = np.arange(len(lat) * len(lon), dtype=np.float32).reshape(
+        (len(lat), len(lon))
+    )
+    _write_cloud_density_slice(
+        path,
+        valid_time="2026-01-01T00:00:00",
+        level=300,
+        lat=lat,
+        lon=lon,
+        values=values,
+    )
+
+    out_lat, out_lon, out_values = volume_routes._read_cloud_density_grid(
+        path, lat_bounds=(2.8, 1.2), lon_bounds=(12.8, 11.2)
+    )
+    assert np.array_equal(out_lat, np.array([1.0, 2.0, 3.0]))
+    assert np.array_equal(out_lon, np.array([11.0, 12.0, 13.0]))
+    assert np.array_equal(out_values, values[1:4, 1:4])
+
+
+def test_read_cloud_density_grid_raises_when_missing_cloud_density_var(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "grid-missing-var.nc"
+    ds = xr.Dataset(
+        {"temperature": (("lat", "lon"), np.zeros((2, 2), dtype=np.float32))},
+        coords={"lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    ds.to_netcdf(path, engine="h5netcdf")
+
+    with pytest.raises(HTTPException) as excinfo:
+        volume_routes._read_cloud_density_grid(path)
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Slice missing cloud_density"
+
+
+def test_read_cloud_density_grid_raises_when_dims_not_lat_lon(tmp_path: Path) -> None:
+    path = tmp_path / "grid-wrong-dims.nc"
+    ds = xr.Dataset(
+        {
+            "cloud_density": (
+                ("time", "lat", "lon"),
+                np.zeros((2, 2, 2), dtype=np.float32),
+            )
+        },
+        coords={
+            "time": [np.datetime64("2026-01-01"), np.datetime64("2026-01-02")],
+            "lat": [0.0, 1.0],
+            "lon": [0.0, 1.0],
+        },
+    )
+    ds.to_netcdf(path, engine="h5netcdf")
+
+    with pytest.raises(HTTPException) as excinfo:
+        volume_routes._read_cloud_density_grid(path)
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Slice must have lat/lon dimensions"
+
+
+def test_read_cloud_density_grid_raises_when_non_monotonic_and_bounds_used(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "grid-non-monotonic-bounds.nc"
+    lat = [0.0, 0.2, 0.1]
+    lon = [0.0, 0.1, 0.2]
+    values = np.ones((len(lat), len(lon)), dtype=np.float32)
+    _write_cloud_density_slice(
+        path,
+        valid_time="2026-01-01T00:00:00",
+        level=300,
+        lat=lat,
+        lon=lon,
+        values=values,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        volume_routes._read_cloud_density_grid(path, lat_bounds=(0.0, 1.0))
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Slice coordinates are not monotonic"
+
+
+def test_read_cloud_density_grid_raises_when_non_monotonic_without_bounds(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "grid-non-monotonic.nc"
+    lat = [0.0, 0.2, 0.1]
+    lon = [0.0, 0.1, 0.2]
+    values = np.ones((len(lat), len(lon)), dtype=np.float32)
+    _write_cloud_density_slice(
+        path,
+        valid_time="2026-01-01T00:00:00",
+        level=300,
+        lat=lat,
+        lon=lon,
+        values=values,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        volume_routes._read_cloud_density_grid(path)
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Slice coordinates are not monotonic"
+
+
+def test_read_cloud_density_grid_raises_when_data_shape_is_invalid(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "grid-invalid-shape.nc"
+    ds = xr.Dataset(
+        {"cloud_density": (("lon", "lat"), np.zeros((2, 3), dtype=np.float32))},
+        coords={"lat": [0.0, 1.0, 2.0], "lon": [10.0, 11.0]},
+    )
+    ds.to_netcdf(path, engine="h5netcdf")
+
+    with pytest.raises(HTTPException) as excinfo:
+        volume_routes._read_cloud_density_grid(path)
+    assert excinfo.value.status_code == 500
+    assert excinfo.value.detail == "Slice has invalid data shape"
+
+
+def test_read_cloud_density_grid_returns_empty_lat_selection_for_empty_coord(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "grid-empty-lat.nc"
+    ds = xr.Dataset(
+        {"cloud_density": (("lat", "lon"), np.empty((0, 2), dtype=np.float32))},
+        coords={"lat": np.array([], dtype=np.float64), "lon": [0.0, 1.0]},
+    )
+    ds.to_netcdf(path, engine="h5netcdf")
+
+    out_lat, out_lon, out_values = volume_routes._read_cloud_density_grid(
+        path, lat_bounds=(0.0, 1.0)
+    )
+    assert out_lat.size == 0
+    assert np.array_equal(out_lon, np.array([0.0, 1.0]))
+    assert out_values.shape == (0, 2)
+
+
+def test_read_cloud_density_grid_returns_empty_lon_selection_for_empty_coord(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "grid-empty-lon.nc"
+    ds = xr.Dataset(
+        {"cloud_density": (("lat", "lon"), np.empty((2, 0), dtype=np.float32))},
+        coords={"lat": [0.0, 1.0], "lon": np.array([], dtype=np.float64)},
+    )
+    ds.to_netcdf(path, engine="h5netcdf")
+
+    out_lat, out_lon, out_values = volume_routes._read_cloud_density_grid(
+        path, lon_bounds=(0.0, 1.0)
+    )
+    assert np.array_equal(out_lat, np.array([0.0, 1.0]))
+    assert out_lon.size == 0
+    assert out_values.shape == (2, 0)
+
+
+@pytest.mark.parametrize(
+    ("bbox", "message"),
+    [
+        ("", "bbox must not be empty"),
+        ("0,0,foo,1,0,1", "bbox values must be valid numbers"),
+        ("0,0,1,1,0,inf", "bbox values must be finite numbers"),
+        ("0,1,1,0,0,1", "bbox north must be > south"),
+    ],
+)
+def test_parse_bbox_rejects_edge_cases(bbox: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        volume_routes._parse_bbox(bbox)
+
+
+@pytest.mark.parametrize(
+    ("levels", "message"),
+    [
+        ("", "levels must not be empty"),
+        (" , , ", "levels must not be empty"),
+        ("300,inf", "levels must be finite numbers"),
+    ],
+)
+def test_parse_levels_rejects_edge_cases(levels: str, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        volume_routes._parse_levels(levels)
+
+
+def test_parse_levels_preserves_non_integer_values() -> None:
+    assert volume_routes._parse_levels("500.5") == ("500.5",)
+
+
+def test_parse_valid_time_rejects_empty_and_defaults_to_utc() -> None:
+    with pytest.raises(ValueError, match="valid_time must not be empty"):
+        volume_routes._parse_valid_time("")
+
+    parsed = volume_routes._parse_valid_time("2026-01-01T00:00:00")
+    assert parsed == datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_time_key_helpers_accept_naive_datetime() -> None:
+    naive = datetime(2026, 1, 1, 0, 0, 0)
+    assert volume_routes._time_key(naive) == "20260101T000000Z"
+    assert volume_routes._iso_z(naive) == "2026-01-01T00:00:00Z"
+
+
+def test_parse_time_key_returns_none_for_invalid_value() -> None:
+    assert volume_routes._parse_time_key("not-a-time-key") is None
+
+
+def test_misc_helpers_cover_branch_cases() -> None:
+    assert volume_routes._normalize_lon(10.0, np.array([])) == 10.0
+    assert volume_routes._normalize_lon(370.0, np.array([0.0, 180.0, 270.0])) == 10.0
+    assert volume_routes._monotonic_1d(np.zeros((2, 2))) is False
+    assert volume_routes._bounding_slice(np.array([]), 0.0, 1.0) == slice(0, 0)
+
+
+def test_interp_1d_handles_empty_and_single_point() -> None:
+    with pytest.raises(ValueError, match="source coordinate is empty"):
+        volume_routes._interp_1d(np.array([]), np.array([]), np.array([0.0]))
+
+    out = volume_routes._interp_1d(
+        np.array([0.0]),
+        np.array([5.0], dtype=np.float32),
+        np.array([0.0, 1.0], dtype=np.float64),
+    )
+    assert np.array_equal(out, np.array([5.0, 5.0], dtype=np.float32))
+
+
+def test_interp2d_validates_inputs() -> None:
+    with pytest.raises(ValueError, match="lat/lon must be 1D coordinates"):
+        volume_routes._interp2d(
+            lat=np.zeros((2, 2)),
+            lon=np.array([0.0, 1.0]),
+            values=np.zeros((2, 2), dtype=np.float32),
+            target_lat=np.array([0.0]),
+            target_lon=np.array([0.0]),
+        )
+
+    with pytest.raises(ValueError, match="values must have shape"):
+        volume_routes._interp2d(
+            lat=np.array([0.0, 1.0]),
+            lon=np.array([0.0, 1.0]),
+            values=np.zeros((3, 3), dtype=np.float32),
+            target_lat=np.array([0.0]),
+            target_lon=np.array([0.0]),
+        )
+
+
+def test_volume_returns_400_for_non_numeric_res(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    client = _make_client(monkeypatch, tmp_path)
+    response = client.get(
+        "/api/v1/volume",
+        params={
+            "bbox": "0,0,0.1,0.1,0,1",
+            "levels": "300",
+            "res": "not-a-number",
+        },
     )
     assert response.status_code == 400


### PR DESCRIPTION
## Summary

Fixes P1 DoS vulnerabilities identified in post-merge review of PR #324:

- **P1-1**: `_target_grid()` allocated arrays before `MAX_OUTPUT_BYTES` check
  - Added `_estimate_grid_size()` to compute dimensions without allocation
  - Size check now happens before any `np.linspace` calls

- **P1-2**: `_read_cloud_density_grid()` loaded full NetCDF slice regardless of bbox
  - Added `lat_bounds` and `lon_bounds` parameters for lazy subsetting
  - Uses xarray `.sel()` to read only requested region before `.values`

## Changes

- `apps/api/src/routes/volume.py`:
  - Add `_estimate_grid_size()` for pre-allocation size check (line 392)
  - Add `_bounding_slice_monotonic()` for descending coordinate handling
  - Update `_read_cloud_density_grid()` with bbox bounds subsetting (line 333)
  - Add `_read_cloud_density_coords()` for coordinate-only reads
  - Move longitude normalization before level loop

## Test plan

- [x] All 14 existing tests pass
- [x] Lint and format checks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)