### PR TITLE
feat(api): Volume API caching, rate limit, and audit logging (#172)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -262,7 +262,11 @@
             "$ref": "#/components/schemas/ParticleSizeRange"
           },
           "risk_level": {
-            "$ref": "#/components/schemas/RiskLevel",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
             "readOnly": true
           },
           "spawn_rate": {
@@ -486,7 +490,6 @@
           "app_state": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -498,7 +501,6 @@
           "browser_info": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -812,7 +814,6 @@
             "type": "string"
           },
           "meta": {
-            "additionalProperties": true,
             "title": "Meta",
             "type": "object"
           },
@@ -1100,6 +1101,9 @@
           "type": {
             "const": "FeatureCollection",
             "default": "FeatureCollection",
+            "enum": [
+              "FeatureCollection"
+            ],
             "title": "Type",
             "type": "string"
           }
@@ -1123,6 +1127,9 @@
           "type": {
             "const": "Feature",
             "default": "Feature",
+            "enum": [
+              "Feature"
+            ],
             "title": "Type",
             "type": "string"
           }
@@ -1406,7 +1413,6 @@
             "type": "string"
           },
           "snapshot": {
-            "additionalProperties": true,
             "title": "Snapshot",
             "type": "object"
           },
@@ -1691,7 +1697,11 @@
         "additionalProperties": false,
         "properties": {
           "direction": {
-            "$ref": "#/components/schemas/ThresholdDirection",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ThresholdDirection"
+              }
+            ],
             "default": "ascending"
           },
           "id": {
@@ -2026,7 +2036,6 @@
         "additionalProperties": false,
         "properties": {
           "definition": {
-            "additionalProperties": true,
             "title": "Definition",
             "type": "object"
           },
@@ -3114,7 +3123,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "title": "Response Get Cldas Summary Api V1 Local Data Cldas Summary Get",
                   "type": "object"
                 }
@@ -3266,7 +3274,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "title": "Response Get Town Forecast Api V1 Local Data Town Forecast Get",
                   "type": "object"
                 }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -262,11 +262,7 @@
             "$ref": "#/components/schemas/ParticleSizeRange"
           },
           "risk_level": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RiskLevel"
-              }
-            ],
+            "$ref": "#/components/schemas/RiskLevel",
             "readOnly": true
           },
           "spawn_rate": {
@@ -490,6 +486,7 @@
           "app_state": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -501,6 +498,7 @@
           "browser_info": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -814,6 +812,7 @@
             "type": "string"
           },
           "meta": {
+            "additionalProperties": true,
             "title": "Meta",
             "type": "object"
           },
@@ -1101,9 +1100,6 @@
           "type": {
             "const": "FeatureCollection",
             "default": "FeatureCollection",
-            "enum": [
-              "FeatureCollection"
-            ],
             "title": "Type",
             "type": "string"
           }
@@ -1127,9 +1123,6 @@
           "type": {
             "const": "Feature",
             "default": "Feature",
-            "enum": [
-              "Feature"
-            ],
             "title": "Type",
             "type": "string"
           }
@@ -1413,6 +1406,7 @@
             "type": "string"
           },
           "snapshot": {
+            "additionalProperties": true,
             "title": "Snapshot",
             "type": "object"
           },
@@ -1697,11 +1691,7 @@
         "additionalProperties": false,
         "properties": {
           "direction": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ThresholdDirection"
-              }
-            ],
+            "$ref": "#/components/schemas/ThresholdDirection",
             "default": "ascending"
           },
           "id": {
@@ -2036,6 +2026,7 @@
         "additionalProperties": false,
         "properties": {
           "definition": {
+            "additionalProperties": true,
             "title": "Definition",
             "type": "object"
           },
@@ -3123,6 +3114,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "title": "Response Get Cldas Summary Api V1 Local Data Cldas Summary Get",
                   "type": "object"
                 }
@@ -3274,6 +3266,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "title": "Response Get Town Forecast Api V1 Local Data Town Forecast Get",
                   "type": "object"
                 }

--- a/apps/api/src/routes/volume.py
+++ b/apps/api/src/routes/volume.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 import math
 import os
+import time
+from asyncio import to_thread
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Final
+from typing import Final, Protocol
 
 import numpy as np
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import Response
 
+from config import get_settings
 from datacube.storage import open_datacube
 from volume.cloud_density import DEFAULT_CLOUD_DENSITY_LAYER
 from volume.pack import encode_volume_pack
@@ -22,6 +26,15 @@ router = APIRouter(tags=["volume"])
 
 VOLUME_DATA_DIR_ENV: Final[str] = "DIGITAL_EARTH_VOLUME_DATA_DIR"
 
+DEFAULT_VOLUME_CACHE_TTL_SECONDS: Final[int] = 3600
+VOLUME_CACHE_KEY_PREFIX: Final[str] = "volume:cache:"
+
+VOLUME_AUDIT_KEY_PREFIX: Final[str] = "volume:audit:"
+VOLUME_AUDIT_TTL_SECONDS: Final[int] = 86400 * 7
+
+VOLUME_STATS_DEFAULT_LIMIT: Final[int] = 10
+VOLUME_STATS_MAX_LIMIT: Final[int] = 100
+
 MAX_BBOX_AREA_DEG2: Final[float] = 100.0
 MIN_RES_METERS: Final[float] = 100.0
 MAX_OUTPUT_BYTES: Final[int] = 64 * 1024 * 1024
@@ -30,6 +43,117 @@ METERS_PER_DEG_LAT: Final[float] = 111_320.0
 
 _TIME_KEY_FORMAT: Final[str] = "%Y%m%dT%H%M%SZ"
 _ISO_Z_FORMAT: Final[str] = "%Y-%m-%dT%H:%M:%SZ"
+
+_BBOX_BUCKET_DEG_STEP: Final[float] = 1.0
+_BBOX_BUCKET_M_STEP: Final[float] = 1000.0
+
+
+class RedisVolumeLike(Protocol):
+    async def get(self, key: str) -> bytes | None: ...
+
+    async def set(
+        self,
+        key: str,
+        value: bytes,
+        *,
+        ex: int | None = None,
+        px: int | None = None,
+        nx: bool = False,
+    ) -> object: ...
+
+    async def expire(self, key: str, seconds: int) -> object: ...
+
+    async def zincrby(self, key: str, amount: int | float, member: str) -> object: ...
+
+    async def zrevrange(
+        self,
+        key: str,
+        start: int,
+        end: int,
+        *,
+        withscores: bool = False,
+    ) -> object: ...
+
+
+def _cache_key(bbox: str, levels: str, valid_time: str | None, res: float) -> str:
+    raw = f"{bbox}|{levels}|{valid_time or 'latest'}|{res}"
+    digest = hashlib.sha256(raw.encode()).hexdigest()[:32]
+    return f"{VOLUME_CACHE_KEY_PREFIX}{digest}"
+
+
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        first = forwarded.split(",")[0].strip()
+        if first:
+            return first
+    if request.client is not None and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _format_bucket_value(value: float) -> str:
+    if abs(value - round(value)) < 1e-9:
+        return str(int(round(value)))
+    return str(float(value))
+
+
+def _quantize(value: float, *, step: float) -> float:
+    if step <= 0:
+        return float(value)
+    return round(float(value) / step) * step
+
+
+def _bbox_bucket_from_parsed(bbox: BBox) -> str:
+    parts = (
+        _format_bucket_value(_quantize(bbox.west, step=_BBOX_BUCKET_DEG_STEP)),
+        _format_bucket_value(_quantize(bbox.south, step=_BBOX_BUCKET_DEG_STEP)),
+        _format_bucket_value(_quantize(bbox.east, step=_BBOX_BUCKET_DEG_STEP)),
+        _format_bucket_value(_quantize(bbox.north, step=_BBOX_BUCKET_DEG_STEP)),
+        _format_bucket_value(_quantize(bbox.bottom, step=_BBOX_BUCKET_M_STEP)),
+        _format_bucket_value(_quantize(bbox.top, step=_BBOX_BUCKET_M_STEP)),
+    )
+    return ",".join(parts)
+
+
+def _bbox_bucket(value: str) -> str:
+    parsed = _parse_bbox(value)
+    return _bbox_bucket_from_parsed(parsed)
+
+
+async def _log_volume_request(
+    redis: RedisVolumeLike | None,
+    *,
+    bbox: str,
+    levels: str,
+    res: float,
+    client_ip: str,
+    response_time_ms: int,
+    cache_hit: bool,
+) -> None:
+    logger.info(
+        "volume_request",
+        extra={
+            "bbox": bbox,
+            "levels": levels,
+            "res": float(res),
+            "client_ip": client_ip,
+            "response_time_ms": int(response_time_ms),
+            "cache_hit": bool(cache_hit),
+        },
+    )
+
+    if redis is None:
+        return
+
+    hour_key = datetime.now(timezone.utc).strftime("%Y%m%d%H")
+    audit_key = f"{VOLUME_AUDIT_KEY_PREFIX}{hour_key}"
+    try:
+        bucket = _bbox_bucket(bbox)
+        await redis.zincrby(audit_key, 1, bucket)
+        await redis.expire(audit_key, VOLUME_AUDIT_TTL_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("volume_audit_redis_error", extra={"error": str(exc)})
 
 
 @dataclass(frozen=True)
@@ -418,79 +542,24 @@ def _target_grid(bbox: BBox, *, res_m: float) -> tuple[np.ndarray, np.ndarray]:
     return target_lat, target_lon
 
 
-@router.get(
-    "/volume",
-    response_class=Response,
-    responses={
-        200: {
-            "description": "Volume Pack binary payload",
-            "content": {
-                "application/octet-stream": {
-                    "schema": {"type": "string", "format": "binary"}
-                }
-            },
-        },
-        400: {"description": "Bad Request"},
-        404: {"description": "Not Found"},
-        500: {"description": "Internal Server Error"},
-        503: {"description": "Service Unavailable"},
-    },
-)
-def get_volume(
-    bbox: str = Query(
-        ...,
-        description="west,south,east,north,bottom,top (degrees/meters)",
-        examples=["-10,20,10,40,0,12000"],
-    ),
-    levels: str = Query(..., description="Comma-separated pressure levels (hPa)"),
-    res: float = Query(..., description="Horizontal resolution in meters"),
-    valid_time: str | None = Query(default=None, description="ISO8601 timestamp"),
-) -> Response:
-    try:
-        bbox_parsed = _parse_bbox(bbox)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    try:
-        levels_keys = _parse_levels(levels)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    try:
-        res_m = float(res)
-    except (TypeError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail="res must be a number") from exc
-    if not math.isfinite(res_m) or res_m <= 0:
-        raise HTTPException(status_code=400, detail="res must be a positive number")
-    if res_m < MIN_RES_METERS:
-        raise HTTPException(status_code=400, detail="res is below minimum")
-
-    dt: datetime | None = None
-    if valid_time is not None:
-        try:
-            dt = _parse_valid_time(valid_time)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    try:
-        n_lat, n_lon = _estimate_grid_size(bbox_parsed, res_m=res_m)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    estimated_bytes = int(len(levels_keys)) * n_lat * n_lon * 4
-    if estimated_bytes > MAX_OUTPUT_BYTES:
-        raise HTTPException(status_code=400, detail="Requested volume exceeds max size")
-
-    target_lat, target_lon = _target_grid(bbox_parsed, res_m=res_m)
+def _compute_volume_payload(
+    *,
+    bbox: BBox,
+    levels_keys: tuple[str, ...],
+    res_m: float,
+    valid_time: datetime | None,
+) -> bytes:
+    target_lat, target_lon = _target_grid(bbox, res_m=res_m)
 
     base_dir = _resolve_volume_base_dir()
     _time_key, resolved_dt, time_dir = _resolve_time_dir(
-        base_dir, layer=DEFAULT_CLOUD_DENSITY_LAYER, valid_time=dt
+        base_dir, layer=DEFAULT_CLOUD_DENSITY_LAYER, valid_time=valid_time
     )
 
     reference_slice_path = _resolve_slice_path(time_dir, level_key=levels_keys[0])
     _, reference_lon = _read_cloud_density_coords(reference_slice_path)
-    lon_w = _normalize_lon(bbox_parsed.west, reference_lon)
-    lon_e = _normalize_lon(bbox_parsed.east, reference_lon)
+    lon_w = _normalize_lon(bbox.west, reference_lon)
+    lon_e = _normalize_lon(bbox.east, reference_lon)
     if lon_e <= lon_w:
         raise HTTPException(status_code=400, detail="bbox crosses longitude seam")
 
@@ -501,7 +570,7 @@ def get_volume(
         slice_path = _resolve_slice_path(time_dir, level_key=level_key)
         lat, lon, values = _read_cloud_density_grid(
             slice_path,
-            lat_bounds=(bbox_parsed.south, bbox_parsed.north),
+            lat_bounds=(bbox.south, bbox.north),
             lon_bounds=(lon_w, lon_e),
         )
 
@@ -509,7 +578,7 @@ def get_volume(
         lat_sorted, lat_order = _sorted_axis(lat)
         values_sorted = values[np.ix_(lat_order, lon_order)]
 
-        lat_slice = _bounding_slice(lat_sorted, bbox_parsed.south, bbox_parsed.north)
+        lat_slice = _bounding_slice(lat_sorted, bbox.south, bbox.north)
         lon_slice = _bounding_slice(lon_sorted, lon_w, lon_e)
         if lat_slice.stop == 0 or lon_slice.stop == 0:
             raise HTTPException(status_code=404, detail="bbox outside dataset")
@@ -542,7 +611,7 @@ def get_volume(
     volume = np.stack(slices, axis=0).astype(np.float32, copy=False)
 
     header = {
-        "bbox": bbox_parsed.to_header(),
+        "bbox": bbox.to_header(),
         "levels": [
             int(level) if level.isdigit() else float(level) for level in levels_keys
         ],
@@ -564,4 +633,165 @@ def get_volume(
     if len(payload) > MAX_OUTPUT_BYTES:
         raise HTTPException(status_code=400, detail="Encoded volume exceeds max size")
 
+    return payload
+
+
+@router.get(
+    "/volume",
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Volume Pack binary payload",
+            "content": {
+                "application/octet-stream": {
+                    "schema": {"type": "string", "format": "binary"}
+                }
+            },
+        },
+        400: {"description": "Bad Request"},
+        404: {"description": "Not Found"},
+        500: {"description": "Internal Server Error"},
+        503: {"description": "Service Unavailable"},
+    },
+)
+async def get_volume(
+    request: Request,
+    bbox: str = Query(
+        ...,
+        description="west,south,east,north,bottom,top (degrees/meters)",
+        examples=["-10,20,10,40,0,12000"],
+    ),
+    levels: str = Query(..., description="Comma-separated pressure levels (hPa)"),
+    res: float = Query(..., description="Horizontal resolution in meters"),
+    valid_time: str | None = Query(default=None, description="ISO8601 timestamp"),
+) -> Response:
+    start = time.perf_counter()
+    bbox_raw = (bbox or "").strip()
+    levels_raw = (levels or "").strip()
+    valid_time_raw = (valid_time or "").strip() if valid_time is not None else None
+
+    try:
+        bbox_parsed = _parse_bbox(bbox_raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        levels_keys = _parse_levels(levels_raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        res_m = float(res)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="res must be a number") from exc
+    if not math.isfinite(res_m) or res_m <= 0:
+        raise HTTPException(status_code=400, detail="res must be a positive number")
+    if res_m < MIN_RES_METERS:
+        raise HTTPException(status_code=400, detail="res is below minimum")
+
+    dt: datetime | None = None
+    if valid_time is not None:
+        try:
+            dt = _parse_valid_time(valid_time_raw or valid_time)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        n_lat, n_lon = _estimate_grid_size(bbox_parsed, res_m=res_m)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    estimated_bytes = int(len(levels_keys)) * n_lat * n_lon * 4
+    if estimated_bytes > MAX_OUTPUT_BYTES:
+        raise HTTPException(status_code=400, detail="Requested volume exceeds max size")
+
+    redis: RedisVolumeLike | None = getattr(request.app.state, "redis_client", None)
+    settings = get_settings()
+    cache_ttl_seconds = int(
+        getattr(
+            settings.api, "volume_cache_ttl_seconds", DEFAULT_VOLUME_CACHE_TTL_SECONDS
+        )
+    )
+
+    payload: bytes | None = None
+    cache_hit = False
+
+    cache_key: str | None = None
+    if redis is not None and cache_ttl_seconds > 0:
+        cache_key = _cache_key(bbox_raw, levels_raw, valid_time_raw, res_m)
+        try:
+            payload = await redis.get(cache_key)
+            cache_hit = payload is not None
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("volume_cache_unavailable", extra={"error": str(exc)})
+            payload = None
+            cache_hit = False
+
+    if payload is None:
+        payload = await to_thread(
+            _compute_volume_payload,
+            bbox=bbox_parsed,
+            levels_keys=levels_keys,
+            res_m=res_m,
+            valid_time=dt,
+        )
+        if redis is not None and cache_key is not None and cache_ttl_seconds > 0:
+            try:
+                await redis.set(cache_key, payload, ex=cache_ttl_seconds)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("volume_cache_set_failed", extra={"error": str(exc)})
+
+    response_time_ms = int(round((time.perf_counter() - start) * 1000))
+    await _log_volume_request(
+        redis,
+        bbox=bbox_raw,
+        levels=levels_raw,
+        res=res_m,
+        client_ip=_client_ip(request),
+        response_time_ms=response_time_ms,
+        cache_hit=cache_hit,
+    )
+
     return Response(content=payload, media_type="application/octet-stream")
+
+
+@router.get("/volume/stats", include_in_schema=False)
+async def get_volume_stats(
+    request: Request,
+    hour: str | None = Query(
+        default=None,
+        description="UTC hour key (YYYYMMDDHH). Defaults to current hour.",
+    ),
+    limit: int = Query(
+        default=VOLUME_STATS_DEFAULT_LIMIT, ge=1, le=VOLUME_STATS_MAX_LIMIT
+    ),
+) -> dict[str, object]:
+    redis: RedisVolumeLike | None = getattr(request.app.state, "redis_client", None)
+    if redis is None:
+        raise HTTPException(status_code=503, detail="Redis not configured")
+
+    hour_key = hour or datetime.now(timezone.utc).strftime("%Y%m%d%H")
+    audit_key = f"{VOLUME_AUDIT_KEY_PREFIX}{hour_key}"
+
+    try:
+        raw = await redis.zrevrange(audit_key, 0, limit - 1, withscores=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("volume_stats_redis_error", extra={"error": str(exc)})
+        raise HTTPException(status_code=503, detail="Failed to query stats") from exc
+
+    items: list[dict[str, object]] = []
+    if isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+                continue
+            member, score = entry
+            if isinstance(member, bytes):
+                bucket = member.decode("utf-8", errors="replace")
+            else:
+                bucket = str(member)
+            try:
+                count = int(score)
+            except (TypeError, ValueError):
+                continue
+            items.append({"bbox_bucket": bucket, "count": count})
+
+    return {"hour": hour_key, "top": items}

--- a/apps/api/tests/redis_fakes.py
+++ b/apps/api/tests/redis_fakes.py
@@ -103,7 +103,9 @@ class FakeRedis:
     ) -> object:
         self._purge_if_expired(key)
         entries = self.zsets.get(key, {})
-        items = sorted(entries.items(), key=lambda item: (item[1], item[0]), reverse=True)
+        items = sorted(
+            entries.items(), key=lambda item: (item[1], item[0]), reverse=True
+        )
 
         resolved_start = max(0, int(start))
         resolved_end = int(end)

--- a/packages/config/src/digital_earth_config/settings.py
+++ b/packages/config/src/digital_earth_config/settings.py
@@ -219,7 +219,7 @@ def _default_api_rate_limit_rules() -> list[ApiRateLimitRule]:
         ApiRateLimitRule(path_prefix="/api/v1/catalog", requests_per_minute=100),
         ApiRateLimitRule(path_prefix="/api/v1/vector", requests_per_minute=60),
         ApiRateLimitRule(path_prefix="/api/v1/tiles", requests_per_minute=300),
-        ApiRateLimitRule(path_prefix="/api/v1/volume", requests_per_minute=30),
+        ApiRateLimitRule(path_prefix="/api/v1/volume", requests_per_minute=10),
         ApiRateLimitRule(path_prefix="/api/v1/errors", requests_per_minute=10),
     ]
 
@@ -258,6 +258,11 @@ class ApiSettings(BaseModel):
     port: int
     debug: bool = False
     cors_origins: list[str] = Field(default_factory=list)
+    volume_cache_ttl_seconds: int = Field(
+        default=3600,
+        ge=0,
+        description="TTL for cached /api/v1/volume responses stored in Redis.",
+    )
     rate_limit: ApiRateLimitSettings = Field(default_factory=ApiRateLimitSettings)
     effect_trigger_logging: ApiEffectTriggerLoggingSettings = Field(
         default_factory=ApiEffectTriggerLoggingSettings

--- a/packages/config/tests/test_settings.py
+++ b/packages/config/tests/test_settings.py
@@ -59,8 +59,9 @@ def test_loads_json_and_requires_db_secrets(
     assert rules["/api/v1/catalog"] == 100
     assert rules["/api/v1/vector"] == 60
     assert rules["/api/v1/tiles"] == 300
-    assert rules["/api/v1/volume"] == 30
+    assert rules["/api/v1/volume"] == 10
     assert rules["/api/v1/errors"] == 10
+    assert settings.api.volume_cache_ttl_seconds == 3600
 
 
 def test_rate_limit_rules_normalize_path_prefix(
@@ -99,10 +100,12 @@ def test_env_overrides_deep_merge(
     monkeypatch.setenv("DIGITAL_EARTH_DB_USER", "app")
     monkeypatch.setenv("DIGITAL_EARTH_DB_PASSWORD", "secret")
     monkeypatch.setenv("DIGITAL_EARTH_API_PORT", "9000")
+    monkeypatch.setenv("DIGITAL_EARTH_API_VOLUME_CACHE_TTL_SECONDS", "120")
 
     settings = Settings()
     assert settings.api.port == 9000
     assert settings.api.host == "0.0.0.0"
+    assert settings.api.volume_cache_ttl_seconds == 120
 
 
 def test_pipeline_precip_type_threshold_loads_and_env_overrides(


### PR DESCRIPTION
## Summary

Implements Volume API caching and rate limiting enhancements for issue #172.

### Features

- **Response Cache**: Hash-based caching using sha256 of (bbox|levels|valid_time|res)
  - Cache key prefix: `volume:cache:`
  - TTL: 1 hour (configurable via `api.volume_cache_ttl_seconds`)
  - Returns cached VolumePack payload on hit

- **Stricter Rate Limit**: Lowered from 30 RPM to 10 RPM for `/api/v1/volume`

- **Audit Logging**: Structured logging for request analysis
  - Fields: bbox, levels, res, client_ip, response_time_ms, cache_hit
  - Hourly Redis ZSET counter keyed by bbox bucket
  - Internal `GET /api/v1/volume/stats` endpoint for top requests

## Changes

| File | Changes |
|------|---------|
| `apps/api/src/routes/volume.py` | Add caching, audit logging, stats endpoint |
| `packages/config/src/digital_earth_config/settings.py` | Lower rate limit, add cache TTL config |
| `apps/api/tests/test_volume_api.py` | Add cache/audit/stats tests |
| `apps/api/tests/redis_fakes.py` | Extend FakeRedis for zincrby, zrevrange, expire |
| `apps/api/openapi.json` | Update snapshot |

## Acceptance Criteria

- [x] 重复请求命中缓存
- [x] 429 生效 (10 RPM)
- [x] 日志可统计 Top 请求 (/volume/stats endpoint)

## Test plan

- [x] All 50 volume tests pass
- [x] Lint and format checks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)