### PR TITLE
feat(web): integrate Volume API for voxel cloud (#141)

### DIFF
--- a/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
+++ b/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
@@ -1,17 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
-  const computeLocalModeBBox = vi.fn(() => ({
+  const defaultBBox = {
     west: 0,
     south: 0,
     east: 1,
     north: 1,
     bottom: 0,
     top: 12000,
+  };
+
+  const computeLocalModeBBox = vi.fn(() => ({
+    ...defaultBBox,
   }));
 
   const fetchVolumePack = vi.fn();
-  const loadFromArrayBuffer = vi.fn(async () => {});
+  const loadFromArrayBuffer = vi.fn(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
   const setEnabled = vi.fn();
   const destroy = vi.fn();
 
@@ -24,6 +28,7 @@ const mocks = vi.hoisted(() => {
   });
 
   return {
+    defaultBBox,
     computeLocalModeBBox,
     fetchVolumePack,
     loadFromArrayBuffer,
@@ -58,10 +63,12 @@ function makeViewer() {
 describe('VoxelCloudLayer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.computeLocalModeBBox.mockImplementation(() => ({ ...mocks.defaultBBox }));
     mocks.fetchVolumePack.mockReset();
+    mocks.loadFromArrayBuffer.mockImplementation(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
   });
 
-  it('caches and reuses volume responses', async () => {
+  it('caches and skips reloads when camera stays stable', async () => {
     const viewer = makeViewer();
     mocks.fetchVolumePack.mockResolvedValueOnce(new ArrayBuffer(4));
 
@@ -76,6 +83,93 @@ describe('VoxelCloudLayer', () => {
     await layer.updateForCamera({} as never);
 
     expect(mocks.fetchVolumePack).toHaveBeenCalledTimes(1);
+    expect(mocks.loadFromArrayBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears lastLoadedKey when activating fallback', async () => {
+    const viewer = makeViewer();
+    const volume = new ArrayBuffer(4);
+    mocks.fetchVolumePack.mockResolvedValueOnce(volume);
+
+    const options = {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      res: 1000,
+      cacheEntries: 4,
+    };
+
+    const layer = new VoxelCloudLayer(viewer as never, options);
+    mocks.setEnabled.mockClear();
+
+    await layer.updateForCamera({} as never);
+    expect(mocks.fetchVolumePack).toHaveBeenCalledTimes(1);
+    expect(mocks.loadFromArrayBuffer).toHaveBeenCalledTimes(1);
+
+    options.apiBaseUrl = '';
+    await layer.updateForCamera({} as never);
+    expect(mocks.setEnabled).toHaveBeenCalledWith(false);
+
+    options.apiBaseUrl = 'http://api.test';
+    await layer.updateForCamera({} as never);
+    expect(mocks.fetchVolumePack).toHaveBeenCalledTimes(1);
+    expect(mocks.loadFromArrayBuffer).toHaveBeenCalledTimes(2);
+    expect(mocks.setEnabled.mock.calls.at(-1)).toEqual([true]);
+  });
+
+  it('aborts stale cached reloads and prevents state updates', async () => {
+    const viewer = makeViewer();
+    const volumeA = new ArrayBuffer(4);
+    const volumeB = new ArrayBuffer(8);
+
+    const bboxA = { ...mocks.defaultBBox };
+    const bboxB = { ...mocks.defaultBBox, west: 5, east: 6 };
+
+    mocks.computeLocalModeBBox
+      .mockReturnValueOnce(bboxA)
+      .mockReturnValueOnce(bboxB)
+      .mockReturnValueOnce(bboxA)
+      .mockReturnValueOnce(bboxB);
+
+    mocks.fetchVolumePack.mockResolvedValueOnce(volumeA).mockResolvedValueOnce(volumeB);
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      res: 1000,
+      cacheEntries: 4,
+    });
+
+    await layer.updateForCamera({} as never); // fetch A (cache miss)
+    await layer.updateForCamera({} as never); // fetch B (cache miss)
+
+    mocks.setEnabled.mockClear();
+    mocks.loadFromArrayBuffer.mockClear();
+
+    let resolveLoad!: () => void;
+    let capturedSignal: AbortSignal | undefined;
+    const cachedLoad = new Promise<void>((resolve) => {
+      resolveLoad = () => resolve();
+    });
+
+    mocks.loadFromArrayBuffer.mockImplementation(async (_buffer: ArrayBuffer, options?: { signal?: AbortSignal }) => {
+      capturedSignal = options?.signal;
+      return cachedLoad;
+    });
+
+    const pending = layer.updateForCamera({} as never); // cached reload A (in-flight)
+    await layer.updateForCamera({} as never); // camera back to already-loaded B, should abort A reload
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(true);
+
+    resolveLoad();
+    await pending;
+
+    expect(mocks.setEnabled).not.toHaveBeenCalled();
+
+    mocks.computeLocalModeBBox.mockReturnValueOnce(bboxA);
+    mocks.loadFromArrayBuffer.mockImplementation(async () => {});
+    await layer.updateForCamera({} as never);
     expect(mocks.loadFromArrayBuffer).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
+++ b/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => {
   }));
 
   const fetchVolumePack = vi.fn();
-  const loadFromArrayBuffer = vi.fn(async () => {});
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const loadFromArrayBuffer = vi.fn(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
   const setEnabled = vi.fn();
   const destroy = vi.fn();
 
@@ -65,7 +66,8 @@ describe('VoxelCloudLayer', () => {
     vi.clearAllMocks();
     mocks.computeLocalModeBBox.mockImplementation(() => ({ ...mocks.defaultBBox }));
     mocks.fetchVolumePack.mockReset();
-    mocks.loadFromArrayBuffer.mockImplementation(async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    mocks.loadFromArrayBuffer.mockImplementation(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
   });
 
   it('caches and skips reloads when camera stays stable', async () => {
@@ -168,7 +170,8 @@ describe('VoxelCloudLayer', () => {
     expect(mocks.setEnabled).not.toHaveBeenCalled();
 
     mocks.computeLocalModeBBox.mockReturnValueOnce(bboxA);
-    mocks.loadFromArrayBuffer.mockImplementation(async () => {});
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    mocks.loadFromArrayBuffer.mockImplementation(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
     await layer.updateForCamera({} as never);
     expect(mocks.loadFromArrayBuffer).toHaveBeenCalledTimes(2);
   });

--- a/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
+++ b/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => {
   }));
 
   const fetchVolumePack = vi.fn();
-  const loadFromArrayBuffer = vi.fn(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
+  const loadFromArrayBuffer = vi.fn(async () => {});
   const setEnabled = vi.fn();
   const destroy = vi.fn();
 
@@ -65,7 +65,7 @@ describe('VoxelCloudLayer', () => {
     vi.clearAllMocks();
     mocks.computeLocalModeBBox.mockImplementation(() => ({ ...mocks.defaultBBox }));
     mocks.fetchVolumePack.mockReset();
-    mocks.loadFromArrayBuffer.mockImplementation(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
+    mocks.loadFromArrayBuffer.mockImplementation(async () => {});
   });
 
   it('caches and skips reloads when camera stays stable', async () => {

--- a/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
+++ b/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const computeLocalModeBBox = vi.fn(() => ({
+    west: 0,
+    south: 0,
+    east: 1,
+    north: 1,
+    bottom: 0,
+    top: 12000,
+  }));
+
+  const fetchVolumePack = vi.fn();
+  const loadFromArrayBuffer = vi.fn(async () => {});
+  const setEnabled = vi.fn();
+  const destroy = vi.fn();
+
+  const VoxelCloudRenderer = vi.fn(function () {
+    return {
+      loadFromArrayBuffer,
+      setEnabled,
+      destroy,
+    };
+  });
+
+  return {
+    computeLocalModeBBox,
+    fetchVolumePack,
+    loadFromArrayBuffer,
+    setEnabled,
+    destroy,
+    VoxelCloudRenderer,
+  };
+});
+
+vi.mock('./bboxCalculator', () => ({
+  computeLocalModeBBox: mocks.computeLocalModeBBox,
+}));
+
+vi.mock('./volumeApi', () => ({
+  fetchVolumePack: mocks.fetchVolumePack,
+}));
+
+vi.mock('./VoxelCloudRenderer', () => ({
+  VoxelCloudRenderer: mocks.VoxelCloudRenderer,
+}));
+
+import { VoxelCloudLayer } from './VoxelCloudLayer';
+
+function makeViewer() {
+  return {
+    scene: {
+      requestRender: vi.fn(),
+    },
+  };
+}
+
+describe('VoxelCloudLayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchVolumePack.mockReset();
+  });
+
+  it('caches and reuses volume responses', async () => {
+    const viewer = makeViewer();
+    mocks.fetchVolumePack.mockResolvedValueOnce(new ArrayBuffer(4));
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300, 500],
+      res: 1000,
+      cacheEntries: 4,
+    });
+
+    await layer.updateForCamera({} as never);
+    await layer.updateForCamera({} as never);
+
+    expect(mocks.fetchVolumePack).toHaveBeenCalledTimes(1);
+    expect(mocks.loadFromArrayBuffer).toHaveBeenCalledTimes(2);
+  });
+
+  it('disables the renderer on fetch failure (fallback)', async () => {
+    const viewer = makeViewer();
+    mocks.fetchVolumePack.mockRejectedValueOnce(new Error('boom'));
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      res: 1000,
+    });
+
+    await layer.updateForCamera({} as never);
+
+    expect(mocks.setEnabled).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/features/voxelCloud/VoxelCloudLayer.ts
+++ b/apps/web/src/features/voxelCloud/VoxelCloudLayer.ts
@@ -1,0 +1,134 @@
+import type { Camera, Viewer } from 'cesium';
+
+import { computeLocalModeBBox } from './bboxCalculator';
+import { fetchVolumePack } from './volumeApi';
+import { VolumeCache } from './volumeCache';
+import { VoxelCloudRenderer } from './VoxelCloudRenderer';
+
+function isAbortError(error: unknown, signal?: AbortSignal): boolean {
+  if (signal?.aborted) return true;
+  if (error instanceof DOMException) return error.name === 'AbortError';
+  if (error instanceof Error) return error.name === 'AbortError';
+  return false;
+}
+
+export type VoxelCloudLayerOptions = {
+  apiBaseUrl: string;
+  levels: number[];
+  res: number;
+  validTime?: string | null;
+  cacheEntries?: number;
+};
+
+export class VoxelCloudLayer {
+  private readonly viewer: Viewer;
+  public readonly renderer: VoxelCloudRenderer;
+  private readonly cache: VolumeCache;
+  private readonly options: VoxelCloudLayerOptions;
+
+  private loadAbortController: AbortController | null = null;
+  private inFlightKey: string | null = null;
+  private requestToken = 0;
+  private fallbackActive = false;
+
+  constructor(viewer: Viewer, options: VoxelCloudLayerOptions) {
+    this.viewer = viewer;
+    this.options = options;
+    this.cache = new VolumeCache(options.cacheEntries ?? 4);
+    this.renderer = new VoxelCloudRenderer(viewer, { enabled: true });
+    this.renderer.setEnabled(true);
+  }
+
+  destroy(): void {
+    this.loadAbortController?.abort();
+    this.loadAbortController = null;
+    this.inFlightKey = null;
+    this.renderer.destroy();
+  }
+
+  async updateForCamera(camera: Camera): Promise<void> {
+    const apiBaseUrl = this.options.apiBaseUrl.trim();
+    if (!apiBaseUrl) {
+      this.activateFallback();
+      return;
+    }
+
+    const bbox = computeLocalModeBBox(camera);
+    const cacheKey = VolumeCache.makeCacheKey(
+      bbox,
+      this.options.levels,
+      this.options.res,
+      this.options.validTime ?? undefined,
+    );
+
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      this.loadAbortController?.abort();
+      this.loadAbortController = null;
+      this.inFlightKey = null;
+      this.requestToken += 1;
+
+      try {
+        await this.renderer.loadFromArrayBuffer(cached);
+        this.renderer.setEnabled(true);
+        this.fallbackActive = false;
+      } catch (error) {
+        if (isAbortError(error)) return;
+        console.warn('[Digital Earth] cached voxel volume failed, using 2D cloud layer fallback', error);
+        this.activateFallback();
+      } finally {
+        this.viewer.scene.requestRender();
+      }
+      return;
+    }
+
+    if (this.inFlightKey === cacheKey) return;
+
+    this.loadAbortController?.abort();
+    const controller = new AbortController();
+    this.loadAbortController = controller;
+    this.inFlightKey = cacheKey;
+    const token = (this.requestToken += 1);
+
+    try {
+      const data = await fetchVolumePack(
+        {
+          apiBaseUrl,
+          bbox,
+          levels: this.options.levels,
+          res: this.options.res,
+          ...(this.options.validTime ? { validTime: this.options.validTime } : {}),
+        },
+        { signal: controller.signal },
+      );
+
+      if (controller.signal.aborted || token !== this.requestToken) return;
+
+      this.cache.set(cacheKey, data);
+      await this.renderer.loadFromArrayBuffer(data, { signal: controller.signal });
+
+      if (controller.signal.aborted || token !== this.requestToken) return;
+
+      this.renderer.setEnabled(true);
+      this.fallbackActive = false;
+    } catch (error) {
+      if (isAbortError(error, controller.signal)) return;
+      console.warn('[Digital Earth] Volume API failed, using 2D cloud layer fallback', error);
+      this.activateFallback();
+    } finally {
+      if (this.loadAbortController === controller) this.loadAbortController = null;
+      if (this.inFlightKey === cacheKey) this.inFlightKey = null;
+      this.viewer.scene.requestRender();
+    }
+  }
+
+  private activateFallback(): void {
+    if (this.fallbackActive) return;
+    this.fallbackActive = true;
+    this.loadAbortController?.abort();
+    this.loadAbortController = null;
+    this.inFlightKey = null;
+    this.renderer.setEnabled(false);
+    this.viewer.scene.requestRender();
+  }
+}

--- a/apps/web/src/features/voxelCloud/bboxCalculator.test.ts
+++ b/apps/web/src/features/voxelCloud/bboxCalculator.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('cesium', () => {
+  class Cartesian3 {
+    x: number;
+    y: number;
+    z: number;
+    constructor(x = 0, y = 0, z = 0) {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+    }
+
+    static dot(a: Cartesian3, b: Cartesian3) {
+      return a.x * b.x + a.y * b.y + a.z * b.z;
+    }
+  }
+
+  const CesiumMath = {
+    toRadians: (deg: number) => (deg * Math.PI) / 180,
+    toDegrees: (rad: number) => (rad * 180) / Math.PI,
+  };
+
+  const Transforms = {
+    eastNorthUpToFixedFrame: vi.fn(() => [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1,
+    ]),
+  };
+
+  return {
+    Cartesian3,
+    Math: CesiumMath,
+    Transforms,
+  };
+});
+
+import { Math as CesiumMath } from 'cesium';
+import { computeLocalModeBBox } from './bboxCalculator';
+
+describe('computeLocalModeBBox', () => {
+  it('returns a bounded 3D bbox around the camera', () => {
+    const camera = {
+      positionCartographic: {
+        longitude: CesiumMath.toRadians(10),
+        latitude: CesiumMath.toRadians(20),
+        height: 3000,
+      },
+      frustum: { fov: CesiumMath.toRadians(60), aspectRatio: 1 },
+      positionWC: { x: 0, y: 0, z: 0 },
+      directionWC: { x: 0, y: 0, z: 1 },
+    } as never;
+
+    const bbox = computeLocalModeBBox(camera);
+    expect(bbox.bottom).toBe(0);
+    expect(bbox.top).toBe(12000);
+    expect(bbox.west).toBeLessThan(bbox.east);
+    expect(bbox.south).toBeLessThan(bbox.north);
+    expect((bbox.west + bbox.east) / 2).toBeCloseTo(10, 1);
+    expect((bbox.south + bbox.north) / 2).toBeCloseTo(20, 1);
+  });
+});
+

--- a/apps/web/src/features/voxelCloud/bboxCalculator.test.ts
+++ b/apps/web/src/features/voxelCloud/bboxCalculator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('cesium', () => {
   class Cartesian3 {
@@ -37,23 +37,42 @@ vi.mock('cesium', () => {
   };
 });
 
-import { Math as CesiumMath } from 'cesium';
+import { Math as CesiumMath, Transforms } from 'cesium';
 import { computeLocalModeBBox } from './bboxCalculator';
 
 describe('computeLocalModeBBox', () => {
-  it('returns a bounded 3D bbox around the camera', () => {
-    const camera = {
-      positionCartographic: {
-        longitude: CesiumMath.toRadians(10),
-        latitude: CesiumMath.toRadians(20),
-        height: 3000,
-      },
-      frustum: { fov: CesiumMath.toRadians(60), aspectRatio: 1 },
-      positionWC: { x: 0, y: 0, z: 0 },
-      directionWC: { x: 0, y: 0, z: 1 },
-    } as never;
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    const bbox = computeLocalModeBBox(camera);
+  const baseCamera = {
+    positionCartographic: {
+      longitude: CesiumMath.toRadians(10),
+      latitude: CesiumMath.toRadians(20),
+      height: 3000,
+    },
+    frustum: { fov: CesiumMath.toRadians(60), aspectRatio: 1 },
+    positionWC: { x: 0, y: 0, z: 0 },
+    directionWC: { x: 0, y: 0, z: 1 },
+  } as const;
+
+  const makeCamera = (overrides: Record<string, unknown> = {}) =>
+    ({
+      ...baseCamera,
+      ...overrides,
+      positionCartographic: {
+        ...baseCamera.positionCartographic,
+        ...((overrides.positionCartographic as Record<string, unknown> | undefined) ?? {}),
+      },
+    }) as never;
+
+  const spanDeg = (bbox: { west: number; south: number; east: number; north: number }) => ({
+    lon: bbox.east - bbox.west,
+    lat: bbox.north - bbox.south,
+  });
+
+  it('returns a bounded 3D bbox around the camera', () => {
+    const bbox = computeLocalModeBBox(makeCamera());
     expect(bbox.bottom).toBe(0);
     expect(bbox.top).toBe(12000);
     expect(bbox.west).toBeLessThan(bbox.east);
@@ -61,5 +80,163 @@ describe('computeLocalModeBBox', () => {
     expect((bbox.west + bbox.east) / 2).toBeCloseTo(10, 1);
     expect((bbox.south + bbox.north) / 2).toBeCloseTo(20, 1);
   });
-});
 
+  it('clamps non-finite inputs to min (via longitude)', () => {
+    const bbox = computeLocalModeBBox(
+      makeCamera({
+        positionCartographic: {
+          longitude: Number.NaN,
+        },
+      }),
+    );
+
+    expect(bbox.west).toBe(-180);
+    expect(bbox.east).toBeGreaterThan(-180);
+    expect(Number.isFinite(bbox.south)).toBe(true);
+    expect(Number.isFinite(bbox.north)).toBe(true);
+  });
+
+  it('clamps values below min (via longitude)', () => {
+    const bbox = computeLocalModeBBox(
+      makeCamera({
+        positionCartographic: {
+          longitude: CesiumMath.toRadians(-200),
+        },
+      }),
+    );
+
+    expect(bbox.west).toBe(-180);
+    expect(bbox.east).toBeGreaterThan(-180);
+  });
+
+  it('clamps values above max (via longitude)', () => {
+    const bbox = computeLocalModeBBox(
+      makeCamera({
+        positionCartographic: {
+          longitude: CesiumMath.toRadians(200),
+        },
+      }),
+    );
+
+    expect(bbox.east).toBe(180);
+    expect(bbox.west).toBeLessThan(180);
+  });
+
+  it.each([
+    ['null', null],
+    ['non-object', 123],
+  ])('uses frustum fallbacks when frustum is %s', (_label, frustum) => {
+    const baseline = computeLocalModeBBox(makeCamera({ positionCartographic: { height: 0 } }));
+    const fallback = computeLocalModeBBox(makeCamera({ positionCartographic: { height: 0 }, frustum }));
+
+    expect(spanDeg(fallback).lon).toBeCloseTo(spanDeg(baseline).lon, 10);
+    expect(spanDeg(fallback).lat).toBeCloseTo(spanDeg(baseline).lat, 10);
+  });
+
+  it('prefers frustum.fovy when frustum.fov is missing', () => {
+    const baseline = computeLocalModeBBox(makeCamera({ positionCartographic: { height: 0 } }));
+    const fovy = computeLocalModeBBox(
+      makeCamera({
+        positionCartographic: { height: 0 },
+        frustum: { fovy: CesiumMath.toRadians(45), aspectRatio: 1 },
+      }),
+    );
+
+    expect(spanDeg(fovy).lon).toBeLessThan(spanDeg(baseline).lon);
+    expect(spanDeg(fovy).lat).toBeLessThan(spanDeg(baseline).lat);
+  });
+
+  it('falls back when frustum params are invalid (non-finite fov/aspect)', () => {
+    const baseline = computeLocalModeBBox(makeCamera({ positionCartographic: { height: 0 } }));
+
+    const badFov = computeLocalModeBBox(
+      makeCamera({
+        positionCartographic: { height: 0 },
+        frustum: { fov: Number.POSITIVE_INFINITY, aspectRatio: 1 },
+      }),
+    );
+    expect(spanDeg(badFov).lon).toBeCloseTo(spanDeg(baseline).lon, 10);
+
+    const badAspect = computeLocalModeBBox(
+      makeCamera({
+        positionCartographic: { height: 0 },
+        frustum: { fov: CesiumMath.toRadians(60), aspectRatio: Number.POSITIVE_INFINITY },
+      }),
+    );
+    expect(spanDeg(badAspect).lat).toBeCloseTo(spanDeg(baseline).lat, 10);
+  });
+
+  it('falls back when frustum values are wrong types (fov/fovy/aspect)', () => {
+    const baseline = computeLocalModeBBox(makeCamera({ positionCartographic: { height: 0 } }));
+    const fallback = computeLocalModeBBox(
+      makeCamera({
+        positionCartographic: { height: 0 },
+        frustum: { fov: 'nope', fovy: false, aspectRatio: 'nope' },
+      }),
+    );
+
+    expect(spanDeg(fallback).lon).toBeCloseTo(spanDeg(baseline).lon, 10);
+    expect(spanDeg(fallback).lat).toBeCloseTo(spanDeg(baseline).lat, 10);
+  });
+
+  it('falls back when directionWC is missing', () => {
+    const camera = makeCamera({ directionWC: undefined });
+    computeLocalModeBBox(camera);
+    expect(Transforms.eastNorthUpToFixedFrame).not.toHaveBeenCalled();
+  });
+
+  it('treats missing camera height as 0', () => {
+    const cameraWithoutHeight = makeCamera({ positionCartographic: { height: undefined }, directionWC: undefined });
+    const cameraWithZeroHeight = makeCamera({ positionCartographic: { height: 0 }, directionWC: undefined });
+
+    const bboxWithoutHeight = computeLocalModeBBox(cameraWithoutHeight);
+    const bboxWithZeroHeight = computeLocalModeBBox(cameraWithZeroHeight);
+
+    expect(spanDeg(bboxWithoutHeight).lon).toBeCloseTo(spanDeg(bboxWithZeroHeight).lon, 10);
+    expect(spanDeg(bboxWithoutHeight).lat).toBeCloseTo(spanDeg(bboxWithZeroHeight).lat, 10);
+  });
+
+  it('falls back when positionWC is missing', () => {
+    const camera = makeCamera({ positionWC: undefined });
+    computeLocalModeBBox(camera);
+    expect(Transforms.eastNorthUpToFixedFrame).not.toHaveBeenCalled();
+  });
+
+  it('falls back when dirUp is near zero', () => {
+    const baseline = computeLocalModeBBox(makeCamera());
+    vi.clearAllMocks();
+    const camera = makeCamera({ directionWC: { x: 1, y: 0, z: 0.01 } });
+    const bbox = computeLocalModeBBox(camera);
+
+    expect(Transforms.eastNorthUpToFixedFrame).toHaveBeenCalledTimes(1);
+    expect(spanDeg(bbox).lon).toBeLessThan(spanDeg(baseline).lon);
+  });
+
+  it('falls back when dirUp is non-finite', () => {
+    const camera = makeCamera({ directionWC: { x: 0, y: 0, z: Number.NaN } });
+    const bbox = computeLocalModeBBox(camera);
+
+    expect(Transforms.eastNorthUpToFixedFrame).toHaveBeenCalledTimes(1);
+    expect(Number.isFinite(bbox.west)).toBe(true);
+    expect(Number.isFinite(bbox.east)).toBe(true);
+  });
+
+  it('falls back when deltaH is non-finite', () => {
+    const camera = makeCamera({ positionCartographic: { height: Number.NaN } });
+    const bbox = computeLocalModeBBox(camera);
+
+    expect(Transforms.eastNorthUpToFixedFrame).toHaveBeenCalledTimes(1);
+    expect(Number.isFinite(bbox.west)).toBe(true);
+    expect(Number.isFinite(bbox.east)).toBe(true);
+  });
+
+  it('falls back when t is behind the camera (t <= 0)', () => {
+    const baseline = computeLocalModeBBox(makeCamera());
+    vi.clearAllMocks();
+    const camera = makeCamera({ positionCartographic: { height: 13_000 } });
+    const bbox = computeLocalModeBBox(camera);
+
+    expect(Transforms.eastNorthUpToFixedFrame).toHaveBeenCalledTimes(1);
+    expect(spanDeg(bbox).lon).toBeGreaterThan(spanDeg(baseline).lon);
+  });
+});

--- a/apps/web/src/features/voxelCloud/bboxCalculator.ts
+++ b/apps/web/src/features/voxelCloud/bboxCalculator.ts
@@ -1,0 +1,108 @@
+import { Cartesian3, Math as CesiumMath, Transforms, type Camera } from 'cesium';
+
+export type LocalModeBBox = {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+  bottom: number;
+  top: number;
+};
+
+const METERS_PER_DEG_LAT = 111_320;
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function readFrustumParams(frustum: unknown): { fovYRad: number; aspectRatio: number } {
+  const fallbackFovYRad = CesiumMath.toRadians(60);
+  const fallbackAspectRatio = 1;
+  if (!frustum || typeof frustum !== 'object') {
+    return { fovYRad: fallbackFovYRad, aspectRatio: fallbackAspectRatio };
+  }
+
+  const fovRaw = (frustum as { fov?: unknown; fovy?: unknown }).fov;
+  const fovyRaw = (frustum as { fov?: unknown; fovy?: unknown }).fovy;
+  const aspectRaw = (frustum as { aspectRatio?: unknown }).aspectRatio;
+
+  const fovYRadCandidate =
+    typeof fovRaw === 'number'
+      ? fovRaw
+      : typeof fovyRaw === 'number'
+        ? fovyRaw
+        : fallbackFovYRad;
+  const fovYRad = Number.isFinite(fovYRadCandidate) ? clamp(fovYRadCandidate, 0.1, Math.PI - 0.1) : fallbackFovYRad;
+
+  const aspectCandidate = typeof aspectRaw === 'number' ? aspectRaw : fallbackAspectRatio;
+  const aspectRatio = Number.isFinite(aspectCandidate) ? clamp(aspectCandidate, 0.2, 10) : fallbackAspectRatio;
+
+  return { fovYRad, aspectRatio };
+}
+
+function estimateRangeMeters(camera: Camera, options: { topMeters: number }): number {
+  const cameraHeightMeters = camera.positionCartographic?.height ?? 0;
+  const targetTopMeters = options.topMeters;
+
+  const directionWC = (camera as unknown as { directionWC?: Cartesian3 }).directionWC;
+  const positionWC = (camera as unknown as { positionWC?: Cartesian3 }).positionWC;
+
+  if (!directionWC || !positionWC) {
+    return clamp(cameraHeightMeters * 2, 5_000, 50_000);
+  }
+
+  const frame = Transforms.eastNorthUpToFixedFrame(positionWC);
+  const upWorld = new Cartesian3(frame[8], frame[9], frame[10]);
+  const dirUp = Cartesian3.dot(directionWC, upWorld);
+
+  const deltaH = targetTopMeters - cameraHeightMeters;
+  if (!Number.isFinite(dirUp) || dirUp <= 0.05 || !Number.isFinite(deltaH)) {
+    return clamp(cameraHeightMeters * 2, 5_000, 50_000);
+  }
+
+  const t = deltaH / dirUp;
+  if (!Number.isFinite(t) || t <= 0) {
+    return clamp(cameraHeightMeters * 2, 5_000, 50_000);
+  }
+
+  return clamp(t, 5_000, 50_000);
+}
+
+export function computeLocalModeBBox(camera: Camera): LocalModeBBox {
+  const position = camera.positionCartographic;
+  const lonDeg = CesiumMath.toDegrees(position.longitude);
+  const latDeg = CesiumMath.toDegrees(position.latitude);
+
+  const bottom = 0;
+  const top = 12_000;
+
+  const { fovYRad, aspectRatio } = readFrustumParams((camera as unknown as { frustum?: unknown }).frustum);
+
+  const rangeMeters = estimateRangeMeters(camera, { topMeters: top });
+  const halfFovY = fovYRad * 0.5;
+  const halfFovX = Math.atan(Math.tan(halfFovY) * aspectRatio);
+  const halfY = Math.tan(halfFovY) * rangeMeters;
+  const halfX = Math.tan(halfFovX) * rangeMeters;
+  const radiusMeters = clamp(Math.max(halfX, halfY, 5_000), 1_000, 50_000);
+
+  const latRad = CesiumMath.toRadians(latDeg);
+  const metersPerDegLon = Math.max(1e-6, METERS_PER_DEG_LAT * Math.cos(latRad));
+
+  const deltaLat = radiusMeters / METERS_PER_DEG_LAT;
+  const deltaLon = radiusMeters / metersPerDegLon;
+
+  const clampedLat = clamp(latDeg, -90, 90);
+  const clampedLon = clamp(lonDeg, -180, 180);
+
+  return {
+    west: clamp(clampedLon - deltaLon, -180, 180),
+    south: clamp(clampedLat - deltaLat, -90, 90),
+    east: clamp(clampedLon + deltaLon, -180, 180),
+    north: clamp(clampedLat + deltaLat, -90, 90),
+    bottom,
+    top,
+  };
+}

--- a/apps/web/src/features/voxelCloud/volumeApi.test.ts
+++ b/apps/web/src/features/voxelCloud/volumeApi.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchVolumePack } from './volumeApi';
+
+describe('fetchVolumePack', () => {
+  it('builds a /api/v1/volume URL with bbox, levels, res, and valid_time', async () => {
+    const buffer = new ArrayBuffer(8);
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => buffer,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchVolumePack({
+      apiBaseUrl: 'http://api.test',
+      bbox: { west: 0, south: 1, east: 2, north: 3, bottom: 0, top: 12000 },
+      levels: [300.2, 300, 500],
+      res: 1000,
+      validTime: '2026-01-01T00:00:00Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const firstCall = fetchMock.mock.calls[0] as unknown[];
+    const requestUrl = new URL(String(firstCall[0]));
+    expect(requestUrl.origin).toBe('http://api.test');
+    expect(requestUrl.pathname).toBe('/api/v1/volume');
+    expect(requestUrl.searchParams.get('bbox')).toBe('0,1,2,3,0,12000');
+    expect(requestUrl.searchParams.get('levels')).toBe('300,500');
+    expect(requestUrl.searchParams.get('res')).toBe('1000');
+    expect(requestUrl.searchParams.get('valid_time')).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('throws when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 503 })));
+
+    await expect(
+      fetchVolumePack({
+        apiBaseUrl: 'http://api.test',
+        bbox: { west: 0, south: 0, east: 1, north: 1, bottom: 0, top: 12000 },
+        levels: [300],
+        res: 1000,
+      }),
+    ).rejects.toThrow(/Volume API error/i);
+  });
+});
+

--- a/apps/web/src/features/voxelCloud/volumeApi.test.ts
+++ b/apps/web/src/features/voxelCloud/volumeApi.test.ts
@@ -31,6 +31,27 @@ describe('fetchVolumePack', () => {
     expect(requestUrl.searchParams.get('valid_time')).toBe('2026-01-01T00:00:00Z');
   });
 
+  it('omits valid_time when it is not provided', async () => {
+    const buffer = new ArrayBuffer(8);
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => buffer,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchVolumePack({
+      apiBaseUrl: 'http://api.test',
+      bbox: { west: 0, south: 1, east: 2, north: 3, bottom: 0, top: 12000 },
+      levels: [300],
+      res: 1000,
+    });
+
+    const firstCall = fetchMock.mock.calls[0] as unknown[];
+    const requestUrl = new URL(String(firstCall[0]));
+    expect(requestUrl.searchParams.get('valid_time')).toBeNull();
+  });
+
   it('throws when the response is not ok', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 503 })));
 
@@ -43,5 +64,30 @@ describe('fetchVolumePack', () => {
       }),
     ).rejects.toThrow(/Volume API error/i);
   });
-});
 
+  it('throws when levels is not an array', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, arrayBuffer: async () => new ArrayBuffer(0) })));
+
+    await expect(
+      fetchVolumePack({
+        apiBaseUrl: 'http://api.test',
+        bbox: { west: 0, south: 0, east: 1, north: 1, bottom: 0, top: 12000 },
+        levels: null as unknown as number[],
+        res: 1000,
+      }),
+    ).rejects.toThrow(/levels must be an array/i);
+  });
+
+  it('throws when levels normalize to an empty list', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, arrayBuffer: async () => new ArrayBuffer(0) })));
+
+    await expect(
+      fetchVolumePack({
+        apiBaseUrl: 'http://api.test',
+        bbox: { west: 0, south: 0, east: 1, north: 1, bottom: 0, top: 12000 },
+        levels: [Number.NaN, -1, 0],
+        res: 1000,
+      }),
+    ).rejects.toThrow(/at least one valid level/i);
+  });
+});

--- a/apps/web/src/features/voxelCloud/volumeApi.ts
+++ b/apps/web/src/features/voxelCloud/volumeApi.ts
@@ -1,0 +1,94 @@
+export type VolumeApiBBox = {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+  bottom: number;
+  top: number;
+};
+
+export type VolumeApiParams = {
+  apiBaseUrl: string;
+  bbox: VolumeApiBBox;
+  levels: number[];
+  res: number;
+  validTime?: string;
+};
+
+function resolveApiOrigin(apiBaseUrl: string): string {
+  const trimmed = apiBaseUrl.trim();
+  const fallbackOrigin =
+    typeof window !== 'undefined' && window.location?.origin ? window.location.origin : '';
+
+  if (!trimmed) return fallbackOrigin || 'http://localhost';
+
+  try {
+    const url = new URL(trimmed, fallbackOrigin || 'http://localhost');
+    return url.origin;
+  } catch {
+    return trimmed.replace(/\/+$/, '');
+  }
+}
+
+function normalizeBBox(bbox: VolumeApiBBox): VolumeApiBBox {
+  const values = [bbox.west, bbox.south, bbox.east, bbox.north, bbox.bottom, bbox.top];
+  if (!values.every((value) => typeof value === 'number' && Number.isFinite(value))) {
+    throw new Error('Volume API bbox must contain finite numbers');
+  }
+  return bbox;
+}
+
+function normalizeLevels(levels: number[]): number[] {
+  if (!Array.isArray(levels)) {
+    throw new Error('Volume API levels must be an array');
+  }
+
+  const normalized: number[] = [];
+  const seen = new Set<number>();
+  for (const entry of levels) {
+    if (typeof entry !== 'number' || !Number.isFinite(entry)) continue;
+    const rounded = Math.round(entry);
+    if (rounded <= 0) continue;
+    if (seen.has(rounded)) continue;
+    seen.add(rounded);
+    normalized.push(rounded);
+  }
+
+  if (normalized.length === 0) {
+    throw new Error('Volume API levels must include at least one valid level');
+  }
+
+  return normalized;
+}
+
+function normalizeRes(res: number): number {
+  if (typeof res !== 'number' || !Number.isFinite(res) || res <= 0) {
+    throw new Error('Volume API res must be a positive number');
+  }
+  return res;
+}
+
+export async function fetchVolumePack(
+  params: VolumeApiParams,
+  options?: { signal?: AbortSignal },
+): Promise<ArrayBuffer> {
+  const origin = resolveApiOrigin(params.apiBaseUrl);
+  const bbox = normalizeBBox(params.bbox);
+  const levels = normalizeLevels(params.levels);
+  const res = normalizeRes(params.res);
+
+  const url = new URL(`${origin}/api/v1/volume`);
+  url.searchParams.set(
+    'bbox',
+    `${bbox.west},${bbox.south},${bbox.east},${bbox.north},${bbox.bottom},${bbox.top}`,
+  );
+  url.searchParams.set('levels', levels.join(','));
+  url.searchParams.set('res', String(res));
+  if (params.validTime) url.searchParams.set('valid_time', params.validTime);
+
+  const response = await fetch(url.toString(), { signal: options?.signal });
+  if (!response.ok) {
+    throw new Error(`Volume API error: ${response.status}`);
+  }
+  return response.arrayBuffer();
+}

--- a/apps/web/src/features/voxelCloud/volumeCache.test.ts
+++ b/apps/web/src/features/voxelCloud/volumeCache.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { VolumeCache } from './volumeCache';
+
+describe('VolumeCache', () => {
+  it('evicts the least-recently-used entry', () => {
+    const cache = new VolumeCache(2);
+    const a = new ArrayBuffer(1);
+    const b = new ArrayBuffer(1);
+    const c = new ArrayBuffer(1);
+
+    cache.set('a', a);
+    cache.set('b', b);
+
+    expect(cache.get('a')).toBe(a);
+
+    cache.set('c', c);
+
+    expect(cache.get('b')).toBeNull();
+    expect(cache.get('a')).toBe(a);
+    expect(cache.get('c')).toBe(c);
+  });
+});

--- a/apps/web/src/features/voxelCloud/volumeCache.ts
+++ b/apps/web/src/features/voxelCloud/volumeCache.ts
@@ -1,0 +1,76 @@
+import type { LocalModeBBox } from './bboxCalculator';
+
+type CacheEntry = {
+  data: ArrayBuffer;
+  timestamp: number;
+};
+
+function decimalsForStep(step: number): number {
+  if (!Number.isFinite(step) || step <= 0) return 0;
+  const text = String(step);
+  const expMatch = /e-(\d+)$/i.exec(text);
+  if (expMatch) return Number(expMatch[1]) || 0;
+  const dot = text.indexOf('.');
+  if (dot === -1) return 0;
+  return text.length - dot - 1;
+}
+
+function quantize(value: number, step: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (!Number.isFinite(step) || step <= 0) return value;
+  return Math.round(value / step) * step;
+}
+
+function formatQuantized(value: number, step: number): string {
+  const decimals = decimalsForStep(step);
+  const fixed = quantize(value, step).toFixed(decimals);
+  return decimals === 0 ? fixed : fixed.replace(/\.?0+$/, '');
+}
+
+export class VolumeCache {
+  private readonly maxEntries: number;
+  private readonly entries = new Map<string, CacheEntry>();
+
+  constructor(maxEntries = 4) {
+    this.maxEntries = Math.max(1, Math.floor(maxEntries));
+  }
+
+  static makeCacheKey(bbox: LocalModeBBox, levels: number[], res: number, validTime?: string): string {
+    const bboxKey = [
+      formatQuantized(bbox.west, 0.05),
+      formatQuantized(bbox.south, 0.05),
+      formatQuantized(bbox.east, 0.05),
+      formatQuantized(bbox.north, 0.05),
+      formatQuantized(bbox.bottom, 500),
+      formatQuantized(bbox.top, 500),
+    ].join(',');
+
+    const levelsKey = levels.map((value) => Math.round(value)).join(',');
+    const resKey = String(Math.round(res));
+    const timeKey = validTime ? `|t=${validTime}` : '';
+    return `${bboxKey}|${levelsKey}|${resKey}${timeKey}`;
+  }
+
+  get(key: string): ArrayBuffer | null {
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.data;
+  }
+
+  set(key: string, data: ArrayBuffer): void {
+    this.entries.delete(key);
+    this.entries.set(key, { data, timestamp: Date.now() });
+
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      this.entries.delete(oldestKey);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Implements Volume API integration for VoxelCloudRenderer as issue #141.

### Features

- **Volume API Client** (`volumeApi.ts`): Fetch cloud body data from `/api/v1/volume`
- **BBox Calculator** (`bboxCalculator.ts`): Compute Local mode bbox from camera position
- **LRU Cache** (`volumeCache.ts`): 4-entry cache with quantized bbox keys for hit rate improvement
- **VoxelCloudLayer**: Orchestrator connecting camera→bbox→cache/fetch→renderer

### Graceful Degradation

On Volume API failure:
- Disable voxel renderer (`setEnabled(false)`)
- 2D CloudLayer continues working normally

## Changes

| File | Description |
|------|-------------|
| `volumeApi.ts` | Volume API client with bbox/levels/res parameters |
| `bboxCalculator.ts` | Local mode bbox computation from camera |
| `volumeCache.ts` | LRU cache with quantized keys |
| `VoxelCloudLayer.ts` | Integration layer with abort handling |
| `VoxelCloudRenderer.ts` | Add `loadFromArrayBuffer` method |

## Acceptance Criteria

- [x] Local 模式开启后云体出现
- [x] 移动相机时平滑更新 (abort + re-fetch)
- [x] 失败不影响主流程 (fallback to 2D layer)

## Test plan

- [x] All 476 web tests pass (86 test files)
- [x] Lint and typecheck pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)