### PR TITLE
feat(web): implement voxel cloud LOD and performance mode switch (#142)

### DIFF
--- a/apps/web/src/components/ui/VoxelCloudQualityControl.test.tsx
+++ b/apps/web/src/components/ui/VoxelCloudQualityControl.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const STORAGE_KEY = 'digital-earth.performanceMode';
+
+async function importFresh() {
+  vi.resetModules();
+  const mod = await import('./VoxelCloudQualityControl');
+  const store = await import('../../state/performanceMode');
+  return { ...mod, ...store };
+}
+
+describe('VoxelCloudQualityControl', () => {
+  it('updates voxel cloud quality and auto-downgrade in the performance store', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { VoxelCloudQualityControl, usePerformanceModeStore } = await importFresh();
+    const user = userEvent.setup();
+
+    render(<VoxelCloudQualityControl />);
+
+    const select = screen.getByLabelText('Voxel cloud quality') as HTMLSelectElement;
+    expect(select.value).toBe('high');
+
+    fireEvent.change(select, { target: { value: 'unknown' } });
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('high');
+
+    await user.selectOptions(select, 'low');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('low');
+
+    const checkbox = screen.getByLabelText('Auto-downgrade (FPS)') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    await user.click(checkbox);
+    expect(usePerformanceModeStore.getState().autoDowngrade).toBe(false);
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as Record<string, unknown> | null;
+    expect(persisted).toMatchObject({ voxelCloudQuality: 'low', autoDowngrade: false });
+  });
+});
+

--- a/apps/web/src/components/ui/VoxelCloudQualityControl.tsx
+++ b/apps/web/src/components/ui/VoxelCloudQualityControl.tsx
@@ -1,0 +1,51 @@
+import type { ChangeEvent } from 'react';
+
+import { usePerformanceModeStore } from '../../state/performanceMode';
+import type { VoxelCloudQuality } from '../../features/voxelCloud/qualityConfig';
+
+export type VoxelCloudQualityControlProps = {
+  className?: string;
+};
+
+function isVoxelCloudQuality(value: string): value is VoxelCloudQuality {
+  return value === 'low' || value === 'medium' || value === 'high';
+}
+
+export function VoxelCloudQualityControl(props: VoxelCloudQualityControlProps = {}) {
+  const quality = usePerformanceModeStore((state) => state.voxelCloudQuality);
+  const autoDowngrade = usePerformanceModeStore((state) => state.autoDowngrade);
+  const setVoxelCloudQuality = usePerformanceModeStore((state) => state.setVoxelCloudQuality);
+  const setAutoDowngrade = usePerformanceModeStore((state) => state.setAutoDowngrade);
+
+  const onQualityChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (!isVoxelCloudQuality(value)) return;
+    setVoxelCloudQuality(value);
+  };
+
+  return (
+    <div className={props.className}>
+      <label className="block">
+        <div className="mb-1 text-slate-300">Voxel cloud quality</div>
+        <select
+          className="w-full rounded-md border border-slate-400/20 bg-slate-900/50 px-2 py-1 text-slate-100"
+          value={quality}
+          onChange={onQualityChange}
+        >
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </select>
+      </label>
+
+      <label className="mt-2 flex items-center gap-2 text-xs text-slate-100">
+        <input
+          type="checkbox"
+          checked={autoDowngrade}
+          onChange={(event) => setAutoDowngrade(event.target.checked)}
+        />
+        Auto-downgrade (FPS)
+      </label>
+    </div>
+  );
+}

--- a/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
+++ b/apps/web/src/features/voxelCloud/VoxelCloudLayer.test.ts
@@ -17,12 +17,14 @@ const mocks = vi.hoisted(() => {
   const fetchVolumePack = vi.fn();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const loadFromArrayBuffer = vi.fn(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
+  const setRaySteps = vi.fn();
   const setEnabled = vi.fn();
   const destroy = vi.fn();
 
   const VoxelCloudRenderer = vi.fn(function () {
     return {
       loadFromArrayBuffer,
+      setRaySteps,
       setEnabled,
       destroy,
     };
@@ -33,6 +35,7 @@ const mocks = vi.hoisted(() => {
     computeLocalModeBBox,
     fetchVolumePack,
     loadFromArrayBuffer,
+    setRaySteps,
     setEnabled,
     destroy,
     VoxelCloudRenderer,
@@ -77,7 +80,6 @@ describe('VoxelCloudLayer', () => {
     const layer = new VoxelCloudLayer(viewer as never, {
       apiBaseUrl: 'http://api.test',
       levels: [300, 500],
-      res: 1000,
       cacheEntries: 4,
     });
 
@@ -96,7 +98,6 @@ describe('VoxelCloudLayer', () => {
     const options = {
       apiBaseUrl: 'http://api.test',
       levels: [300],
-      res: 1000,
       cacheEntries: 4,
     };
 
@@ -134,10 +135,15 @@ describe('VoxelCloudLayer', () => {
 
     mocks.fetchVolumePack.mockResolvedValueOnce(volumeA).mockResolvedValueOnce(volumeB);
 
+    const nowMock = vi.spyOn(performance, 'now');
+    nowMock
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(600)
+      .mockReturnValue(1200);
+
     const layer = new VoxelCloudLayer(viewer as never, {
       apiBaseUrl: 'http://api.test',
       levels: [300],
-      res: 1000,
       cacheEntries: 4,
     });
 
@@ -174,6 +180,8 @@ describe('VoxelCloudLayer', () => {
     mocks.loadFromArrayBuffer.mockImplementation(async (_buffer: ArrayBuffer, _options?: { signal?: AbortSignal }) => {});
     await layer.updateForCamera({} as never);
     expect(mocks.loadFromArrayBuffer).toHaveBeenCalledTimes(2);
+
+    nowMock.mockRestore();
   });
 
   it('disables the renderer on fetch failure (fallback)', async () => {
@@ -183,11 +191,427 @@ describe('VoxelCloudLayer', () => {
     const layer = new VoxelCloudLayer(viewer as never, {
       apiBaseUrl: 'http://api.test',
       levels: [300],
-      res: 1000,
     });
 
     await layer.updateForCamera({} as never);
 
     expect(mocks.setEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('falls back when cached reload fails', async () => {
+    const viewer = makeViewer();
+    const volumeA = new ArrayBuffer(4);
+    const volumeB = new ArrayBuffer(8);
+
+    const bboxA = { ...mocks.defaultBBox };
+    const bboxB = { ...mocks.defaultBBox, west: 5, east: 6 };
+    mocks.computeLocalModeBBox.mockReturnValueOnce(bboxA).mockReturnValueOnce(bboxB).mockReturnValueOnce(bboxA);
+
+    mocks.fetchVolumePack.mockResolvedValueOnce(volumeA).mockResolvedValueOnce(volumeB);
+
+    const nowMock = vi.spyOn(performance, 'now');
+    nowMock
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(600)
+      .mockReturnValue(1200);
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+    });
+
+    await layer.updateForCamera({} as never); // fetch A
+    await layer.updateForCamera({} as never); // fetch B
+
+    mocks.setEnabled.mockClear();
+    mocks.loadFromArrayBuffer.mockRejectedValueOnce(new Error('bad cached volume'));
+
+    await layer.updateForCamera({} as never); // cached reload A -> error -> fallback
+
+    expect(mocks.fetchVolumePack).toHaveBeenCalledTimes(2);
+    expect(mocks.setEnabled).toHaveBeenCalledWith(false);
+
+    nowMock.mockRestore();
+  });
+
+  it('uses quality presets for res and ray steps', async () => {
+    const viewer = makeViewer();
+    mocks.fetchVolumePack.mockResolvedValueOnce(new ArrayBuffer(4)).mockResolvedValueOnce(new ArrayBuffer(8));
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      quality: 'high',
+    });
+
+    expect(mocks.setRaySteps).toHaveBeenCalledWith(128);
+
+    await layer.updateForCamera({} as never);
+    expect(mocks.fetchVolumePack).toHaveBeenCalledWith(expect.objectContaining({ res: 1000 }), expect.anything());
+
+    layer.setQuality('low');
+    expect(mocks.setRaySteps).toHaveBeenCalledWith(32);
+
+    await layer.updateForCamera({} as never);
+    expect(mocks.fetchVolumePack).toHaveBeenCalledWith(expect.objectContaining({ res: 4000 }), expect.anything());
+  });
+
+  it('resets the performance monitor when disabling autoDowngrade', () => {
+    const viewer = makeViewer();
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      quality: 'high',
+      autoDowngrade: true,
+    });
+
+    for (let i = 0; i < 29; i += 1) {
+      layer.recordFrame(1000 / 20);
+    }
+
+    layer.setAutoDowngrade(false);
+    layer.setAutoDowngrade(true);
+    layer.recordFrame(1000 / 20);
+
+    expect(layer.quality).toBe('high');
+  });
+
+  it('auto-downgrades and upgrades quality based on sustained FPS', () => {
+    const viewer = makeViewer();
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      quality: 'high',
+      autoDowngrade: true,
+    });
+
+    mocks.setRaySteps.mockClear();
+
+    for (let i = 0; i < 30; i += 1) {
+      layer.recordFrame(1000 / 20);
+    }
+
+    expect(layer.quality).toBe('medium');
+    expect(mocks.setRaySteps).toHaveBeenCalledWith(64);
+
+    for (let i = 0; i < 30; i += 1) {
+      layer.recordFrame(1000 / 60);
+    }
+
+    expect(layer.quality).toBe('high');
+    expect(mocks.setRaySteps).toHaveBeenCalledWith(128);
+  });
+
+  it('does not auto-adjust quality when autoDowngrade is disabled', () => {
+    const viewer = makeViewer();
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      quality: 'high',
+      autoDowngrade: false,
+    });
+
+    for (let i = 0; i < 60; i += 1) {
+      layer.recordFrame(1000 / 10);
+    }
+
+    expect(layer.quality).toBe('high');
+  });
+
+  it('throttles API calls based on preset updateInterval', async () => {
+    const viewer = makeViewer();
+
+    const bboxA = { ...mocks.defaultBBox };
+    const bboxB = { ...mocks.defaultBBox, west: 5, east: 6 };
+    mocks.computeLocalModeBBox.mockReturnValueOnce(bboxA).mockReturnValueOnce(bboxB);
+
+    let resolveFetch!: (buffer: ArrayBuffer) => void;
+    let capturedSignal: AbortSignal | undefined;
+    const fetchPromise = new Promise<ArrayBuffer>((resolve) => {
+      resolveFetch = (buffer) => resolve(buffer);
+    });
+
+    mocks.fetchVolumePack.mockImplementation(async (_params: unknown, options?: { signal?: AbortSignal }) => {
+      capturedSignal = options?.signal;
+      return fetchPromise;
+    });
+
+    const nowMock = vi.spyOn(performance, 'now');
+    nowMock
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(100)
+      .mockReturnValue(1000);
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      quality: 'high',
+    });
+
+    const pending = layer.updateForCamera({} as never);
+    await layer.updateForCamera({} as never);
+
+    expect(mocks.fetchVolumePack).toHaveBeenCalledTimes(1);
+    expect(capturedSignal?.aborted).toBe(true);
+
+    resolveFetch(new ArrayBuffer(4));
+    await pending;
+
+    nowMock.mockRestore();
+  });
+
+  it('records frames from viewer postRender when available', () => {
+    const listeners: Array<() => void> = [];
+    const viewer = {
+      scene: {
+        requestRender: vi.fn(),
+        postRender: {
+          addEventListener: vi.fn((listener: () => void) => listeners.push(listener)),
+          removeEventListener: vi.fn((listener: () => void) => {
+            const index = listeners.indexOf(listener);
+            if (index >= 0) listeners.splice(index, 1);
+          }),
+        },
+      },
+    };
+
+    const nowMock = vi.spyOn(performance, 'now');
+    nowMock
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(16.666)
+      .mockReturnValue(33.333);
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+    });
+
+    const recordSpy = vi.spyOn(layer, 'recordFrame');
+
+    expect(viewer.scene.postRender.addEventListener).toHaveBeenCalledTimes(1);
+    expect(listeners).toHaveLength(1);
+
+    listeners[0]?.();
+    expect(recordSpy).not.toHaveBeenCalled();
+
+    listeners[0]?.();
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+    expect(recordSpy.mock.calls[0]?.[0]).toBeCloseTo(16.666, 2);
+
+    layer.destroy();
+    expect(viewer.scene.postRender.removeEventListener).toHaveBeenCalledTimes(1);
+
+    nowMock.mockRestore();
+  });
+
+  it('supports quality and autoDowngrade property accessors', () => {
+    const viewer = makeViewer();
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      quality: 'high',
+    });
+
+    expect(layer.quality).toBe('high');
+    layer.quality = 'high';
+
+    layer.autoDowngrade = true;
+    expect(layer.autoDowngrade).toBe(true);
+  });
+
+  it('skips duplicate fetches while the same camera key is in-flight', async () => {
+    const viewer = makeViewer();
+    let resolveFetch!: (buffer: ArrayBuffer) => void;
+    const fetchPromise = new Promise<ArrayBuffer>((resolve) => {
+      resolveFetch = (buffer) => resolve(buffer);
+    });
+
+    mocks.fetchVolumePack.mockReturnValue(fetchPromise);
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+    });
+
+    const pending = layer.updateForCamera({} as never);
+    await layer.updateForCamera({} as never);
+
+    expect(mocks.fetchVolumePack).toHaveBeenCalledTimes(1);
+
+    resolveFetch(new ArrayBuffer(4));
+    await pending;
+  });
+
+  it('includes validTime in Volume API requests', async () => {
+    const viewer = makeViewer();
+    mocks.fetchVolumePack.mockResolvedValueOnce(new ArrayBuffer(4));
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      validTime: '2024-01-01T00:00:00Z',
+    });
+
+    await layer.updateForCamera({} as never);
+    expect(mocks.fetchVolumePack).toHaveBeenCalledWith(
+      expect.objectContaining({ validTime: '2024-01-01T00:00:00Z' }),
+      expect.anything(),
+    );
+  });
+
+  it('does not re-activate fallback when already active', async () => {
+    const viewer = makeViewer();
+    const options = {
+      apiBaseUrl: '',
+      levels: [300],
+    };
+
+    const layer = new VoxelCloudLayer(viewer as never, options);
+    mocks.setEnabled.mockClear();
+
+    await layer.updateForCamera({} as never);
+    await layer.updateForCamera({} as never);
+
+    expect(mocks.setEnabled).toHaveBeenCalledTimes(1);
+    expect(mocks.setEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('skips duplicate cached reloads while a cached load is in-flight', async () => {
+    const viewer = makeViewer();
+    const volume = new ArrayBuffer(4);
+    mocks.fetchVolumePack.mockResolvedValueOnce(volume);
+
+    const options = {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+    };
+
+    const layer = new VoxelCloudLayer(viewer as never, options);
+    await layer.updateForCamera({} as never);
+
+    options.apiBaseUrl = '';
+    await layer.updateForCamera({} as never);
+
+    options.apiBaseUrl = 'http://api.test';
+
+    let resolveLoad!: () => void;
+    const cachedLoad = new Promise<void>((resolve) => {
+      resolveLoad = () => resolve();
+    });
+    mocks.loadFromArrayBuffer.mockImplementation(async () => cachedLoad);
+    mocks.loadFromArrayBuffer.mockClear();
+
+    const pending = layer.updateForCamera({} as never);
+    await layer.updateForCamera({} as never);
+
+    expect(mocks.loadFromArrayBuffer).toHaveBeenCalledTimes(1);
+
+    resolveLoad();
+    await pending;
+  });
+
+  it('treats AbortError during cached reload as cancellation', async () => {
+    const viewer = makeViewer();
+    const volume = new ArrayBuffer(4);
+    mocks.fetchVolumePack.mockResolvedValueOnce(volume);
+
+    const options = {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+    };
+
+    const layer = new VoxelCloudLayer(viewer as never, options);
+    await layer.updateForCamera({} as never);
+
+    options.apiBaseUrl = '';
+    await layer.updateForCamera({} as never);
+
+    mocks.setEnabled.mockClear();
+    mocks.loadFromArrayBuffer.mockRejectedValueOnce(new DOMException('aborted', 'AbortError'));
+
+    options.apiBaseUrl = 'http://api.test';
+    await layer.updateForCamera({} as never);
+
+    expect(mocks.setEnabled).not.toHaveBeenCalled();
+  });
+
+  it('treats AbortError during fetch as cancellation', async () => {
+    const viewer = makeViewer();
+    mocks.fetchVolumePack.mockRejectedValueOnce(new DOMException('aborted', 'AbortError'));
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+    });
+    mocks.setEnabled.mockClear();
+
+    await layer.updateForCamera({} as never);
+    expect(mocks.setEnabled).not.toHaveBeenCalled();
+  });
+
+  it('aborts in-flight requests on destroy', async () => {
+    const viewer = makeViewer();
+    let resolveFetch!: (buffer: ArrayBuffer) => void;
+    let capturedSignal: AbortSignal | undefined;
+    const fetchPromise = new Promise<ArrayBuffer>((resolve) => {
+      resolveFetch = (buffer) => resolve(buffer);
+    });
+
+    mocks.fetchVolumePack.mockImplementation(async (_params: unknown, options?: { signal?: AbortSignal }) => {
+      capturedSignal = options?.signal;
+      return fetchPromise;
+    });
+
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+    });
+
+    const pending = layer.updateForCamera({} as never);
+    layer.destroy();
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(true);
+
+    resolveFetch(new ArrayBuffer(4));
+    await pending;
+  });
+
+  it('auto-downgrades from medium to low', () => {
+    const viewer = makeViewer();
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      quality: 'medium',
+      autoDowngrade: true,
+    });
+
+    mocks.setRaySteps.mockClear();
+
+    for (let i = 0; i < 30; i += 1) {
+      layer.recordFrame(1000 / 20);
+    }
+
+    expect(layer.quality).toBe('low');
+    expect(mocks.setRaySteps).toHaveBeenCalledWith(32);
+  });
+
+  it('auto-upgrades from low to medium', () => {
+    const viewer = makeViewer();
+    const layer = new VoxelCloudLayer(viewer as never, {
+      apiBaseUrl: 'http://api.test',
+      levels: [300],
+      quality: 'low',
+      autoDowngrade: true,
+    });
+
+    mocks.setRaySteps.mockClear();
+
+    for (let i = 0; i < 30; i += 1) {
+      layer.recordFrame(1000 / 60);
+    }
+
+    expect(layer.quality).toBe('medium');
+    expect(mocks.setRaySteps).toHaveBeenCalledWith(64);
   });
 });

--- a/apps/web/src/features/voxelCloud/VoxelCloudRenderer.test.ts
+++ b/apps/web/src/features/voxelCloud/VoxelCloudRenderer.test.ts
@@ -271,4 +271,17 @@ describe('VoxelCloudRenderer', () => {
 
     await expect(renderer.loadFromUrl('http://test/volume.volp')).rejects.toThrow(/postProcessStages/i);
   });
+
+  it('setRaySteps updates maxSteps with clamping', () => {
+    const viewer = makeViewer();
+    const renderer = new VoxelCloudRenderer(viewer as never, { enabled: true });
+
+    expect(renderer.getSnapshot().settings.maxSteps).toBe(128);
+
+    renderer.setRaySteps(64);
+    expect(renderer.getSnapshot().settings.maxSteps).toBe(64);
+
+    renderer.setRaySteps(999);
+    expect(renderer.getSnapshot().settings.maxSteps).toBe(512);
+  });
 });

--- a/apps/web/src/features/voxelCloud/VoxelCloudRenderer.ts
+++ b/apps/web/src/features/voxelCloud/VoxelCloudRenderer.ts
@@ -184,6 +184,11 @@ export class VoxelCloudRenderer {
     this.viewer.scene.requestRender();
   }
 
+  setRaySteps(raySteps: number): void {
+    const normalized = Math.round(clamp(raySteps, 1, 512));
+    this.updateSettings({ maxSteps: normalized });
+  }
+
   updateSettings(partial: Partial<Omit<VoxelCloudSettings, 'enabled'>>): void {
     this.settings = { ...this.settings, ...partial };
     this.viewer.scene.requestRender();

--- a/apps/web/src/features/voxelCloud/performanceMonitor.test.ts
+++ b/apps/web/src/features/voxelCloud/performanceMonitor.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { VoxelCloudPerformanceMonitor } from './performanceMonitor';
+
+describe('VoxelCloudPerformanceMonitor', () => {
+  it('computes average FPS from frame deltas', () => {
+    const monitor = new VoxelCloudPerformanceMonitor();
+
+    for (let i = 0; i < 30; i += 1) {
+      monitor.recordFrame(1000 / 60);
+    }
+
+    expect(monitor.getCurrentFps()).toBeGreaterThan(59);
+    expect(monitor.getCurrentFps()).toBeLessThan(61);
+    expect(monitor.shouldUpgrade()).toBe(true);
+    expect(monitor.shouldDowngrade()).toBe(false);
+  });
+
+  it('requires a sustained history before triggering downgrade/upgrade', () => {
+    const monitor = new VoxelCloudPerformanceMonitor();
+
+    for (let i = 0; i < 10; i += 1) {
+      monitor.recordFrame(1000 / 20);
+    }
+
+    expect(monitor.getCurrentFps()).toBeGreaterThan(0);
+    expect(monitor.shouldDowngrade()).toBe(false);
+    expect(monitor.shouldUpgrade()).toBe(false);
+  });
+
+  it('triggers downgrade when sustained FPS is below the threshold', () => {
+    const monitor = new VoxelCloudPerformanceMonitor();
+
+    for (let i = 0; i < 30; i += 1) {
+      monitor.recordFrame(1000 / 20);
+    }
+
+    expect(monitor.getCurrentFps()).toBeGreaterThan(19);
+    expect(monitor.getCurrentFps()).toBeLessThan(21);
+    expect(monitor.shouldDowngrade()).toBe(true);
+    expect(monitor.shouldUpgrade()).toBe(false);
+  });
+
+  it('ignores invalid frame deltas', () => {
+    const monitor = new VoxelCloudPerformanceMonitor();
+
+    monitor.recordFrame(Number.NaN);
+    monitor.recordFrame(-5);
+    monitor.recordFrame(0);
+    monitor.recordFrame(Number.MIN_VALUE);
+
+    expect(monitor.getCurrentFps()).toBe(0);
+    expect(monitor.shouldDowngrade()).toBe(false);
+    expect(monitor.shouldUpgrade()).toBe(false);
+  });
+});

--- a/apps/web/src/features/voxelCloud/performanceMonitor.ts
+++ b/apps/web/src/features/voxelCloud/performanceMonitor.ts
@@ -1,0 +1,33 @@
+export class VoxelCloudPerformanceMonitor {
+  private fpsHistory: number[] = [];
+  private historySize = 30; // ~0.5 second at 60fps
+  private downgradeThreshold = 30;
+  private upgradeThreshold = 50;
+
+  recordFrame(deltaMs: number): void {
+    if (typeof deltaMs !== 'number' || !Number.isFinite(deltaMs) || deltaMs <= 0) return;
+    const fps = 1000 / deltaMs;
+    if (!Number.isFinite(fps) || fps <= 0) return;
+    this.fpsHistory.push(fps);
+    if (this.fpsHistory.length > this.historySize) {
+      this.fpsHistory.splice(0, this.fpsHistory.length - this.historySize);
+    }
+  }
+
+  getCurrentFps(): number {
+    if (this.fpsHistory.length === 0) return 0;
+    const total = this.fpsHistory.reduce((acc, value) => acc + value, 0);
+    return total / this.fpsHistory.length;
+  }
+
+  shouldDowngrade(): boolean {
+    if (this.fpsHistory.length < this.historySize) return false;
+    return this.getCurrentFps() < this.downgradeThreshold;
+  }
+
+  shouldUpgrade(): boolean {
+    if (this.fpsHistory.length < this.historySize) return false;
+    return this.getCurrentFps() > this.upgradeThreshold;
+  }
+}
+

--- a/apps/web/src/features/voxelCloud/qualityConfig.test.ts
+++ b/apps/web/src/features/voxelCloud/qualityConfig.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { QUALITY_PRESETS, type QualityPreset, type VoxelCloudQuality } from './qualityConfig';
+
+describe('qualityConfig', () => {
+  it('exposes the expected preset keys', () => {
+    const keys = Object.keys(QUALITY_PRESETS).sort();
+    expect(keys).toEqual(['high', 'low', 'medium']);
+  });
+
+  it('matches the documented preset values', () => {
+    expect(QUALITY_PRESETS.low).toEqual({ res: 4000, raySteps: 32, updateInterval: 2000 });
+    expect(QUALITY_PRESETS.medium).toEqual({ res: 2000, raySteps: 64, updateInterval: 1000 });
+    expect(QUALITY_PRESETS.high).toEqual({ res: 1000, raySteps: 128, updateInterval: 500 });
+  });
+});
+
+// Compile-time type safety checks.
+const _typedPresets: Record<VoxelCloudQuality, QualityPreset> = QUALITY_PRESETS;
+void _typedPresets;
+

--- a/apps/web/src/features/voxelCloud/qualityConfig.ts
+++ b/apps/web/src/features/voxelCloud/qualityConfig.ts
@@ -1,0 +1,17 @@
+export type VoxelCloudQuality = 'low' | 'medium' | 'high';
+
+export interface QualityPreset {
+  // Grid resolution in meters
+  res: number;
+  // Ray march step count
+  raySteps: number;
+  // Min ms between API calls
+  updateInterval: number;
+}
+
+export const QUALITY_PRESETS = {
+  low: { res: 4000, raySteps: 32, updateInterval: 2000 },
+  medium: { res: 2000, raySteps: 64, updateInterval: 1000 },
+  high: { res: 1000, raySteps: 128, updateInterval: 500 },
+} as const satisfies Record<VoxelCloudQuality, QualityPreset>;
+

--- a/apps/web/src/state/performanceMode.test.ts
+++ b/apps/web/src/state/performanceMode.test.ts
@@ -19,6 +19,8 @@ describe('performanceMode store', () => {
     const { usePerformanceModeStore } = await importFresh();
     expect(usePerformanceModeStore.getState().mode).toBe('high');
     expect(usePerformanceModeStore.getState().enabled).toBe(false);
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('high');
+    expect(usePerformanceModeStore.getState().autoDowngrade).toBe(true);
   });
 
   it('restores a valid persisted mode', async () => {
@@ -26,12 +28,59 @@ describe('performanceMode store', () => {
     const { usePerformanceModeStore } = await importFresh();
     expect(usePerformanceModeStore.getState().mode).toBe('low');
     expect(usePerformanceModeStore.getState().enabled).toBe(true);
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('low');
+    expect(usePerformanceModeStore.getState().autoDowngrade).toBe(true);
+  });
+
+  it('restores a persisted string mode', async () => {
+    writeStorage('low');
+    const { usePerformanceModeStore } = await importFresh();
+    expect(usePerformanceModeStore.getState().mode).toBe('low');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('low');
+  });
+
+  it('falls back to defaults when persisted JSON is invalid', async () => {
+    localStorage.setItem(STORAGE_KEY, '{');
+    const { usePerformanceModeStore } = await importFresh();
+    expect(usePerformanceModeStore.getState().mode).toBe('high');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('high');
+  });
+
+  it('falls back to defaults when persisted state is not an object', async () => {
+    writeStorage(123);
+    const { usePerformanceModeStore } = await importFresh();
+    expect(usePerformanceModeStore.getState().mode).toBe('high');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('high');
   });
 
   it('migrates legacy enabled:true storage to low mode', async () => {
     writeStorage({ enabled: true });
     const { usePerformanceModeStore } = await importFresh();
     expect(usePerformanceModeStore.getState().mode).toBe('low');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('low');
+  });
+
+  it('restores voxelCloudQuality and autoDowngrade when persisted', async () => {
+    writeStorage({ mode: 'high', voxelCloudQuality: 'medium', autoDowngrade: false });
+    const { usePerformanceModeStore } = await importFresh();
+    expect(usePerformanceModeStore.getState().mode).toBe('high');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('medium');
+    expect(usePerformanceModeStore.getState().autoDowngrade).toBe(false);
+  });
+
+  it('falls back to a mode-based quality when persisted voxelCloudQuality is invalid', async () => {
+    writeStorage({ mode: 'low', voxelCloudQuality: 'ultra' });
+    const { usePerformanceModeStore } = await importFresh();
+    expect(usePerformanceModeStore.getState().mode).toBe('low');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('low');
+  });
+
+  it('migrates legacy enabled:false storage to high mode', async () => {
+    writeStorage({ enabled: false });
+    const { usePerformanceModeStore } = await importFresh();
+    expect(usePerformanceModeStore.getState().mode).toBe('high');
+    expect(usePerformanceModeStore.getState().enabled).toBe(false);
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('high');
   });
 
   it('setMode updates state and persists', async () => {
@@ -42,7 +91,16 @@ describe('performanceMode store', () => {
     expect(usePerformanceModeStore.getState().mode).toBe('low');
 
     const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
-    expect(persisted).toEqual({ mode: 'low' });
+    expect(persisted).toEqual({ mode: 'low', voxelCloudQuality: 'high', autoDowngrade: true });
+  });
+
+  it('setMode is a no-op when the value is unchanged', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    usePerformanceModeStore.getState().setMode('high');
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
   it('setEnabled updates mode and persists', async () => {
@@ -53,7 +111,38 @@ describe('performanceMode store', () => {
     expect(usePerformanceModeStore.getState().mode).toBe('low');
 
     const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
-    expect(persisted).toEqual({ mode: 'low' });
+    expect(persisted).toEqual({ mode: 'low', voxelCloudQuality: 'high', autoDowngrade: true });
+  });
+
+  it('setVoxelCloudQuality is a no-op when the value is unchanged', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    usePerformanceModeStore.getState().setVoxelCloudQuality('high');
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('setAutoDowngrade is a no-op when the value is unchanged', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    usePerformanceModeStore.getState().setAutoDowngrade(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('handles localStorage write failures without throwing', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    const { usePerformanceModeStore } = await importFresh();
+    expect(() => usePerformanceModeStore.getState().setMode('low')).not.toThrow();
+    expect(usePerformanceModeStore.getState().mode).toBe('low');
+
+    setItemSpy.mockRestore();
   });
 
   it('toggleMode switches between high and low', async () => {
@@ -65,6 +154,71 @@ describe('performanceMode store', () => {
     expect(usePerformanceModeStore.getState().mode).toBe('low');
     usePerformanceModeStore.getState().toggleMode();
     expect(usePerformanceModeStore.getState().mode).toBe('high');
+  });
+
+  it('setVoxelCloudQuality updates state and persists', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+
+    usePerformanceModeStore.getState().setVoxelCloudQuality('medium');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('medium');
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
+    expect(persisted).toEqual({ mode: 'high', voxelCloudQuality: 'medium', autoDowngrade: true });
+  });
+
+  it('setAutoDowngrade updates state and persists', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+
+    usePerformanceModeStore.getState().setAutoDowngrade(false);
+    expect(usePerformanceModeStore.getState().autoDowngrade).toBe(false);
+
+    const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as unknown;
+    expect(persisted).toEqual({ mode: 'high', voxelCloudQuality: 'high', autoDowngrade: false });
+  });
+
+  it('setState can update voxel cloud flags', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+
+    usePerformanceModeStore.setState({ voxelCloudQuality: 'low', autoDowngrade: false });
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('low');
+    expect(usePerformanceModeStore.getState().autoDowngrade).toBe(false);
+  });
+
+  it('setState can update mode, quality, and autoDowngrade together', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+
+    usePerformanceModeStore.setState({ mode: 'low', voxelCloudQuality: 'medium', autoDowngrade: false });
+    expect(usePerformanceModeStore.getState().mode).toBe('low');
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('medium');
+    expect(usePerformanceModeStore.getState().autoDowngrade).toBe(false);
+  });
+
+  it('setState prefers mode when mode and enabled are both provided', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+
+    usePerformanceModeStore.setState({ mode: 'high', enabled: true });
+    expect(usePerformanceModeStore.getState().mode).toBe('high');
+  });
+
+  it('setState can update mode via enabled when mode is absent', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+
+    usePerformanceModeStore.setState({ enabled: true });
+    expect(usePerformanceModeStore.getState().mode).toBe('low');
+  });
+
+  it('setState ignores invalid voxelCloudQuality values', async () => {
+    localStorage.removeItem(STORAGE_KEY);
+    const { usePerformanceModeStore } = await importFresh();
+
+    usePerformanceModeStore.setState({ voxelCloudQuality: 'ultra' as never });
+    expect(usePerformanceModeStore.getState().voxelCloudQuality).toBe('high');
   });
 
   it('usePerformanceModeStore subscribes via useSyncExternalStore', async () => {
@@ -86,4 +240,3 @@ describe('performanceMode store', () => {
     expect(screen.getByTestId('mode')).toHaveTextContent('low');
   });
 });
-


### PR DESCRIPTION
## Summary
- Quality presets (Low/Med/High) controlling grid resolution, ray march steps, and API update interval
- FPS performance monitor with auto-downgrade/upgrade based on sustained thresholds
- VoxelCloudLayer integrates quality settings with throttled camera updates
- UI control component (dropdown + checkbox) for manual quality selection

## Test plan
- [x] qualityConfig tests verify preset values and types
- [x] performanceMonitor tests verify FPS tracking and threshold detection
- [x] VoxelCloudLayer tests verify quality switching, throttling, and auto-downgrade
- [x] VoxelCloudRenderer tests verify setRaySteps integration
- [x] performanceMode store tests verify state persistence and setters
- [x] UI component tests verify rendering and interaction

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)