### PR TITLE
feat: EC预报多时次多高度层支持及降水/风图层修复 (#336)

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -262,7 +262,11 @@
             "$ref": "#/components/schemas/ParticleSizeRange"
           },
           "risk_level": {
-            "$ref": "#/components/schemas/RiskLevel",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RiskLevel"
+              }
+            ],
             "readOnly": true
           },
           "spawn_rate": {
@@ -486,7 +490,6 @@
           "app_state": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -498,7 +501,6 @@
           "browser_info": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -812,7 +814,6 @@
             "type": "string"
           },
           "meta": {
-            "additionalProperties": true,
             "title": "Meta",
             "type": "object"
           },
@@ -1100,6 +1101,9 @@
           "type": {
             "const": "FeatureCollection",
             "default": "FeatureCollection",
+            "enum": [
+              "FeatureCollection"
+            ],
             "title": "Type",
             "type": "string"
           }
@@ -1123,6 +1127,9 @@
           "type": {
             "const": "Feature",
             "default": "Feature",
+            "enum": [
+              "Feature"
+            ],
             "title": "Type",
             "type": "string"
           }
@@ -1406,7 +1413,6 @@
             "type": "string"
           },
           "snapshot": {
-            "additionalProperties": true,
             "title": "Snapshot",
             "type": "object"
           },
@@ -1691,7 +1697,11 @@
         "additionalProperties": false,
         "properties": {
           "direction": {
-            "$ref": "#/components/schemas/ThresholdDirection",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ThresholdDirection"
+              }
+            ],
             "default": "ascending"
           },
           "id": {
@@ -2026,7 +2036,6 @@
         "additionalProperties": false,
         "properties": {
           "definition": {
-            "additionalProperties": true,
             "title": "Definition",
             "type": "object"
           },
@@ -3114,7 +3123,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "title": "Response Get Cldas Summary Api V1 Local Data Cldas Summary Get",
                   "type": "object"
                 }
@@ -3266,7 +3274,6 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
                   "title": "Response Get Town Forecast Api V1 Local Data Town Forecast Get",
                   "type": "object"
                 }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -262,11 +262,7 @@
             "$ref": "#/components/schemas/ParticleSizeRange"
           },
           "risk_level": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/RiskLevel"
-              }
-            ],
+            "$ref": "#/components/schemas/RiskLevel",
             "readOnly": true
           },
           "spawn_rate": {
@@ -490,6 +486,7 @@
           "app_state": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -501,6 +498,7 @@
           "browser_info": {
             "anyOf": [
               {
+                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -814,6 +812,7 @@
             "type": "string"
           },
           "meta": {
+            "additionalProperties": true,
             "title": "Meta",
             "type": "object"
           },
@@ -1101,9 +1100,6 @@
           "type": {
             "const": "FeatureCollection",
             "default": "FeatureCollection",
-            "enum": [
-              "FeatureCollection"
-            ],
             "title": "Type",
             "type": "string"
           }
@@ -1127,9 +1123,6 @@
           "type": {
             "const": "Feature",
             "default": "Feature",
-            "enum": [
-              "Feature"
-            ],
             "title": "Type",
             "type": "string"
           }
@@ -1413,6 +1406,7 @@
             "type": "string"
           },
           "snapshot": {
+            "additionalProperties": true,
             "title": "Snapshot",
             "type": "object"
           },
@@ -1697,11 +1691,7 @@
         "additionalProperties": false,
         "properties": {
           "direction": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ThresholdDirection"
-              }
-            ],
+            "$ref": "#/components/schemas/ThresholdDirection",
             "default": "ascending"
           },
           "id": {
@@ -2036,6 +2026,7 @@
         "additionalProperties": false,
         "properties": {
           "definition": {
+            "additionalProperties": true,
             "title": "Definition",
             "type": "object"
           },
@@ -3123,6 +3114,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "title": "Response Get Cldas Summary Api V1 Local Data Cldas Summary Get",
                   "type": "object"
                 }
@@ -3274,6 +3266,7 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "additionalProperties": true,
                   "title": "Response Get Town Forecast Api V1 Local Data Town Forecast Get",
                   "type": "object"
                 }

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -31,6 +31,19 @@ it('switches active layer and updates legend', async () => {
       });
     }
 
+    if (url === 'http://api.test/api/v1/catalog/ecmwf/runs?latest=20') {
+      return jsonResponse({
+        runs: [{ run_time: '20251222T000000Z', status: 'complete' }],
+      });
+    }
+
+    if (url === 'http://api.test/api/v1/catalog/ecmwf/runs/2025-12-22T00%3A00%3A00Z/times?policy=std') {
+      return jsonResponse({
+        times: ['20251222T000000Z', '20251222T030000Z'],
+        missing: [],
+      });
+    }
+
     if (url === 'http://api.test/api/v1/legends?layer_type=temperature') {
       return jsonResponse({
         colors: ['#0000ff', '#ffffff', '#ff0000'],

--- a/apps/web/src/features/catalog/ecmwfCatalogApi.ts
+++ b/apps/web/src/features/catalog/ecmwfCatalogApi.ts
@@ -1,0 +1,197 @@
+import { fetchJson, isHttpError } from '../../lib/http';
+
+function normalizeApiBaseUrl(apiBaseUrl: string): string {
+  return apiBaseUrl.trim().replace(/\/+$/, '');
+}
+
+function toUtcIsoNoMillis(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function parseTimeKeyToUtcIso(value: unknown): string | null {
+  if (!isNonEmptyString(value)) return null;
+  const trimmed = value.trim();
+
+  if (/^\d{8}T\d{6}Z$/.test(trimmed)) {
+    const year = Number(trimmed.slice(0, 4));
+    const month = Number(trimmed.slice(4, 6));
+    const day = Number(trimmed.slice(6, 8));
+    const hour = Number(trimmed.slice(9, 11));
+    const minute = Number(trimmed.slice(11, 13));
+    const second = Number(trimmed.slice(13, 15));
+    const ms = Date.UTC(year, month - 1, day, hour, minute, second);
+    const parsed = new Date(ms);
+    return Number.isNaN(parsed.getTime()) ? null : toUtcIsoNoMillis(parsed);
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : toUtcIsoNoMillis(parsed);
+}
+
+export type EcmwfRunStatus = 'complete' | 'partial';
+
+export type EcmwfRun = {
+  runTimeKey: string;
+  status: EcmwfRunStatus;
+};
+
+export type EcmwfRunsResponse = {
+  runs: EcmwfRun[];
+};
+
+export async function getEcmwfRuns(options: {
+  apiBaseUrl: string;
+  latest?: number;
+  limit?: number;
+  offset?: number;
+  signal?: AbortSignal;
+}): Promise<EcmwfRunsResponse> {
+  const base = normalizeApiBaseUrl(options.apiBaseUrl);
+  const url = new URL('/api/v1/catalog/ecmwf/runs', base);
+
+  if (typeof options.latest === 'number') {
+    url.searchParams.set('latest', String(options.latest));
+  } else {
+    if (typeof options.limit === 'number') url.searchParams.set('limit', String(options.limit));
+    if (typeof options.offset === 'number') url.searchParams.set('offset', String(options.offset));
+  }
+
+  try {
+    const payload = await fetchJson<unknown>(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: options.signal,
+    });
+
+    const runs: EcmwfRun[] = [];
+    if (isRecord(payload) && Array.isArray(payload.runs)) {
+      for (const item of payload.runs) {
+        if (!isRecord(item)) continue;
+        const runTimeKey = parseTimeKeyToUtcIso(item.run_time);
+        if (!runTimeKey) continue;
+        const statusRaw = item.status;
+        const status: EcmwfRunStatus = statusRaw === 'complete' ? 'complete' : 'partial';
+        runs.push({ runTimeKey, status });
+      }
+    }
+
+    return { runs };
+  } catch (error) {
+    if (isHttpError(error)) {
+      throw new Error(`Failed to load ECMWF runs: ${error.status}`, { cause: error });
+    }
+    throw error;
+  }
+}
+
+export type EcmwfRunTimesResponse = {
+  times: string[];
+  missing: string[];
+};
+
+export async function getEcmwfRunTimes(options: {
+  apiBaseUrl: string;
+  runTimeKey: string;
+  policy?: 'std';
+  signal?: AbortSignal;
+}): Promise<EcmwfRunTimesResponse> {
+  const base = normalizeApiBaseUrl(options.apiBaseUrl);
+  const run = options.runTimeKey.trim();
+  const url = new URL(`/api/v1/catalog/ecmwf/runs/${encodeURIComponent(run)}/times`, base);
+  url.searchParams.set('policy', options.policy ?? 'std');
+
+  try {
+    const payload = await fetchJson<unknown>(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: options.signal,
+    });
+
+    const times: string[] = [];
+    const missing: string[] = [];
+
+    if (isRecord(payload)) {
+      if (Array.isArray(payload.times)) {
+        for (const value of payload.times) {
+          const parsed = parseTimeKeyToUtcIso(value);
+          if (parsed) times.push(parsed);
+        }
+      }
+
+      if (Array.isArray(payload.missing)) {
+        for (const value of payload.missing) {
+          if (isNonEmptyString(value)) missing.push(value.trim());
+        }
+      }
+    }
+
+    return { times, missing };
+  } catch (error) {
+    if (isHttpError(error)) {
+      throw new Error(`Failed to load ECMWF run times: ${error.status}`, { cause: error });
+    }
+    throw error;
+  }
+}
+
+export type EcmwfRunVarsResponse = {
+  vars: string[];
+  levels: string[];
+  units: Record<string, string>;
+  legendVersion: number;
+};
+
+export async function getEcmwfRunVars(options: {
+  apiBaseUrl: string;
+  runTimeKey: string;
+  signal?: AbortSignal;
+}): Promise<EcmwfRunVarsResponse> {
+  const base = normalizeApiBaseUrl(options.apiBaseUrl);
+  const run = options.runTimeKey.trim();
+  const url = new URL(`/api/v1/catalog/ecmwf/runs/${encodeURIComponent(run)}/vars`, base);
+
+  try {
+    const payload = await fetchJson<unknown>(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: options.signal,
+    });
+
+    if (!isRecord(payload)) {
+      return { vars: [], levels: [], units: {}, legendVersion: 0 };
+    }
+
+    const vars: string[] = Array.isArray(payload.vars)
+      ? payload.vars.filter(isNonEmptyString).map((value) => value.trim())
+      : [];
+    const levels: string[] = Array.isArray(payload.levels)
+      ? payload.levels.filter(isNonEmptyString).map((value) => value.trim())
+      : [];
+
+    const units: Record<string, string> = {};
+    if (isRecord(payload.units)) {
+      for (const [key, value] of Object.entries(payload.units)) {
+        if (!isNonEmptyString(key) || !isNonEmptyString(value)) continue;
+        units[key.trim()] = value.trim();
+      }
+    }
+
+    const legendRaw = payload.legend_version;
+    const legendVersion = typeof legendRaw === 'number' && Number.isFinite(legendRaw) ? legendRaw : 0;
+
+    return { vars, levels, units, legendVersion };
+  } catch (error) {
+    if (isHttpError(error)) {
+      throw new Error(`Failed to load ECMWF run vars: ${error.status}`, { cause: error });
+    }
+    throw error;
+  }
+}

--- a/apps/web/src/features/layers/TemperatureLayer.ts
+++ b/apps/web/src/features/layers/TemperatureLayer.ts
@@ -63,7 +63,7 @@ export class TemperatureLayer {
     return buildEcmwfTemperatureTileUrlTemplate({
       apiBaseUrl: params.apiBaseUrl,
       timeKey: params.timeKey,
-      level: 'sfc',
+      level: params.levelKey ?? 'sfc',
     });
   }
 

--- a/apps/web/src/features/layers/types.ts
+++ b/apps/web/src/features/layers/types.ts
@@ -13,6 +13,7 @@ export type RectangleDegrees = {
 
 export type TemperatureLayerParams = CldasTileUrlTemplateOptions & {
   id: string;
+  levelKey?: string;
   opacity: number;
   visible: boolean;
   zIndex: number;

--- a/apps/web/src/features/layout/AppLayout.test.tsx
+++ b/apps/web/src/features/layout/AppLayout.test.tsx
@@ -30,6 +30,33 @@ function stubLegendApi(fetchMock: ReturnType<typeof vi.fn>) {
       return textResponse('© Cesium · © ECMWF / CLDAS');
     }
 
+    if (url === 'http://api.test/api/v1/catalog/ecmwf/runs?latest=20') {
+      return jsonResponse({
+        runs: [{ run_time: '20251222T000000Z', status: 'complete' }],
+      });
+    }
+
+    if (url === 'http://api.test/api/v1/catalog/ecmwf/runs/2025-12-22T00%3A00%3A00Z/times?policy=std') {
+      return jsonResponse({
+        times: ['20251222T000000Z', '20251222T030000Z'],
+        missing: [],
+      });
+    }
+
+    if (url === 'http://api.test/api/v1/catalog/ecmwf/runs/2025-12-22T00%3A00%3A00Z/vars') {
+      return jsonResponse({
+        vars: ['cloud', 'precip', 'wind', 'temp'],
+        levels: ['sfc', '850', '700', '500', '300'],
+        units: {
+          cloud: '%',
+          precip: 'mm',
+          wind: 'm/s',
+          temp: '°C',
+        },
+        legend_version: 2,
+      });
+    }
+
     if (url === 'http://api.test/api/v1/legends?layer_type=temperature') {
       return jsonResponse({
         colors: ['#0000ff', '#ffffff', '#ff0000'],
@@ -113,7 +140,7 @@ describe('AppLayout', () => {
     expect(screen.getAllByText('50%').length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('button', { name: '预报' }));
-    expect(screen.getByText('该视图尚未实现。')).toBeInTheDocument();
+    expect(screen.getByText('ECMWF 预报')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '返回上一视图' }));
     expect(await screen.findByText('全局')).toBeInTheDocument();

--- a/apps/web/src/features/layout/TimelineBar.tsx
+++ b/apps/web/src/features/layout/TimelineBar.tsx
@@ -1,7 +1,9 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
+import { loadConfig } from '../../config';
 import { GlassPanel } from '../../components/ui/GlassPanel';
 import { DEFAULT_TIME_KEY, useTimeStore } from '../../state/time';
+import { getEcmwfRunTimes, getEcmwfRuns } from '../catalog/ecmwfCatalogApi';
 import { TimeController } from '../timeline/TimeController';
 
 function makeHourlyFrames(baseUtcIso: string, count: number): Date[] {
@@ -17,21 +19,137 @@ function makeHourlyFrames(baseUtcIso: string, count: number): Date[] {
   return frames;
 }
 
+function toUtcIsoNoMillis(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function addHoursUtcIso(baseUtcIso: string, hours: number): string {
+  const base = new Date(baseUtcIso);
+  if (Number.isNaN(base.getTime())) return baseUtcIso;
+  return toUtcIsoNoMillis(new Date(base.getTime() + hours * 60 * 60 * 1000));
+}
+
 export function TimelineBar() {
-  const frames = useMemo(() => makeHourlyFrames(DEFAULT_TIME_KEY, 24), []);
-  const setTimeKey = useTimeStore((state) => state.setTimeKey);
+  const runTimeKey = useTimeStore((state) => state.runTimeKey);
+  const setRunTimeKey = useTimeStore((state) => state.setRunTimeKey);
+  const setValidTimeKey = useTimeStore((state) => state.setValidTimeKey);
+
+  const fallbackFrames = useMemo(() => makeHourlyFrames(DEFAULT_TIME_KEY, 24), []);
+  const [frames, setFrames] = useState<Date[]>(fallbackFrames);
+  const [initialIndex, setInitialIndex] = useState(0);
+  const [controllerKey, setControllerKey] = useState<string>('fallback');
+  const [apiBaseUrl, setApiBaseUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    void loadConfig()
+      .then((config) => {
+        if (cancelled) return null;
+        setApiBaseUrl(config.apiBaseUrl);
+        return getEcmwfRuns({ apiBaseUrl: config.apiBaseUrl, latest: 20, signal: controller.signal });
+      })
+      .then((result) => {
+        if (cancelled) return;
+        const latest = result?.runs[0]?.runTimeKey;
+        if (!latest) return;
+        const current = useTimeStore.getState().runTimeKey;
+        if (result?.runs.some((run) => run.runTimeKey === current)) return;
+        setRunTimeKey(latest);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.warn('[TimelineBar] failed to load ECMWF runs', error);
+        setApiBaseUrl(null);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [setRunTimeKey]);
+
+  useEffect(() => {
+    if (!apiBaseUrl) return;
+    if (!runTimeKey) return;
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    void getEcmwfRunTimes({
+      apiBaseUrl,
+      runTimeKey,
+      policy: 'std',
+      signal: controller.signal,
+    })
+      .then((result) => {
+        if (cancelled) return;
+        const nextFrames = result.times
+          .map((value) => new Date(value))
+          .filter((value) => !Number.isNaN(value.getTime()));
+
+        if (nextFrames.length === 0) {
+          setFrames(fallbackFrames);
+          setInitialIndex(0);
+          setControllerKey(`fallback:${fallbackFrames.length}`);
+          return;
+        }
+
+        const frameKeys = nextFrames.map(toUtcIsoNoMillis);
+        const currentValidTimeKey = useTimeStore.getState().validTimeKey;
+        const normalizedCurrentValid = currentValidTimeKey.replace(/\.\d{3}Z$/, 'Z');
+
+        let nextIndex = frameKeys.indexOf(normalizedCurrentValid);
+        let nextValidTimeKey = normalizedCurrentValid;
+
+        if (nextIndex < 0) {
+          const preferred = addHoursUtcIso(runTimeKey, 3);
+          const preferredIndex = frameKeys.indexOf(preferred);
+          if (preferredIndex >= 0) {
+            nextIndex = preferredIndex;
+            nextValidTimeKey = preferred;
+          } else {
+            nextIndex = 0;
+            nextValidTimeKey = frameKeys[0] ?? normalizedCurrentValid;
+          }
+
+          if (nextValidTimeKey && nextValidTimeKey !== normalizedCurrentValid) {
+            setValidTimeKey(nextValidTimeKey);
+          }
+        }
+
+        setFrames(nextFrames);
+        setInitialIndex(Math.max(0, nextIndex));
+        setControllerKey(
+          `${runTimeKey}:${nextFrames.length}:${nextFrames[0]!.getTime()}:${nextFrames[nextFrames.length - 1]!.getTime()}`,
+        );
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.warn('[TimelineBar] failed to load ECMWF run times', error);
+        setFrames(fallbackFrames);
+        setInitialIndex(0);
+        setControllerKey(`fallback:${fallbackFrames.length}`);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [apiBaseUrl, fallbackFrames, runTimeKey, setValidTimeKey]);
 
   return (
     <GlassPanel className="h-16 px-4 flex items-center">
       <TimeController
+        key={controllerKey}
         frames={frames}
+        initialIndex={initialIndex}
         baseIntervalMs={1000}
         onRefreshLayers={(time) => {
-          const iso = time.toISOString().replace(/\.\d{3}Z$/, 'Z');
-          setTimeKey(iso);
+          setValidTimeKey(toUtcIsoNoMillis(time));
         }}
       />
     </GlassPanel>
   );
 }
-

--- a/apps/web/src/features/viewer/CesiumViewer.test.tsx
+++ b/apps/web/src/features/viewer/CesiumViewer.test.tsx
@@ -440,7 +440,7 @@ import { useLayerManagerStore } from '../../state/layerManager';
 import { useOsmBuildingsStore } from '../../state/osmBuildings';
 import { usePerformanceModeStore } from '../../state/performanceMode';
 import { DEFAULT_SCENE_MODE_ID, useSceneModeStore } from '../../state/sceneMode';
-import { DEFAULT_TIME_KEY, useTimeStore } from '../../state/time';
+import { DEFAULT_LEVEL_KEY, DEFAULT_RUN_TIME_KEY, DEFAULT_TIME_KEY, useTimeStore } from '../../state/time';
 import { useViewModeStore } from '../../state/viewMode';
 import { useViewerStatsStore } from '../../state/viewerStats';
 import { CesiumViewer } from './CesiumViewer';
@@ -479,7 +479,11 @@ describe('CesiumViewer', () => {
     useEventAutoLayersStore.setState({ restoreOnExit: true, overrides: {} });
     useEventLayersStore.setState({ enabled: true, mode: DEFAULT_EVENT_LAYER_MODE });
     useSceneModeStore.setState({ sceneModeId: DEFAULT_SCENE_MODE_ID });
-    useTimeStore.setState({ timeKey: DEFAULT_TIME_KEY });
+    useTimeStore.setState({
+      runTimeKey: DEFAULT_RUN_TIME_KEY,
+      validTimeKey: DEFAULT_TIME_KEY,
+      levelKey: DEFAULT_LEVEL_KEY,
+    });
     useLayerManagerStore.setState({ layers: [] });
     useOsmBuildingsStore.setState({ enabled: false });
     usePerformanceModeStore.setState({ mode: 'high' });
@@ -1332,7 +1336,7 @@ describe('CesiumViewer', () => {
       ([url]) => typeof url === 'string' && url.includes('/api/v1/vector/ecmwf/'),
     );
     expect(windCall?.[0]).toContain(
-      `/api/v1/vector/ecmwf/${encodeURIComponent(DEFAULT_TIME_KEY)}/wind/sfc/${encodeURIComponent(DEFAULT_TIME_KEY)}`,
+      `/api/v1/vector/ecmwf/${encodeURIComponent(DEFAULT_RUN_TIME_KEY)}/wind/${encodeURIComponent(DEFAULT_LEVEL_KEY)}/${encodeURIComponent(DEFAULT_TIME_KEY)}`,
     );
     expect(windCall?.[0]).toContain('bbox=10,20,30,40');
     expect(windCall?.[0]).toContain('stride=');

--- a/apps/web/src/features/viewer/CesiumViewer.tsx
+++ b/apps/web/src/features/viewer/CesiumViewer.tsx
@@ -44,7 +44,7 @@ import { useLayoutPanelsStore } from '../../state/layoutPanels';
 import { useOsmBuildingsStore } from '../../state/osmBuildings';
 import { usePerformanceModeStore } from '../../state/performanceMode';
 import { useSceneModeStore } from '../../state/sceneMode';
-import { DEFAULT_TIME_KEY, useTimeStore } from '../../state/time';
+import { useTimeStore } from '../../state/time';
 import { useViewerStatsStore } from '../../state/viewerStats';
 import { useViewModeStore, type ViewModeRoute } from '../../state/viewMode';
 import { AircraftDemoLayer } from '../aircraft/AircraftDemoLayer';
@@ -663,7 +663,9 @@ export function CesiumViewer() {
   const canGoBack = useViewModeStore((state) => state.canGoBack);
   const goBack = useViewModeStore((state) => state.goBack);
   const layers = useLayerManagerStore((state) => state.layers);
+  const runTimeKey = useTimeStore((state) => state.runTimeKey);
   const timeKey = useTimeStore((state) => state.timeKey);
+  const levelKey = useTimeStore((state) => state.levelKey);
   const eventLayersEnabled = useEventLayersStore((state) => state.enabled);
   const eventLayersMode = useEventLayersStore((state) => state.mode);
   const performanceMode = usePerformanceModeStore((state) => state.mode);
@@ -2770,18 +2772,18 @@ export function CesiumViewer() {
         const [first, second] = await Promise.all([
           fetchWindVectorData({
             apiBaseUrl: apiBaseUrl ?? '',
-            runTimeKey: DEFAULT_TIME_KEY,
+            runTimeKey,
             timeKey,
-            level: 'sfc',
+            level: levelKey,
             bbox: { ...options.bbox, east: 180 },
             density: options.density,
             signal: options.signal,
           }),
           fetchWindVectorData({
             apiBaseUrl: apiBaseUrl ?? '',
-            runTimeKey: DEFAULT_TIME_KEY,
+            runTimeKey,
             timeKey,
-            level: 'sfc',
+            level: levelKey,
             bbox: { ...options.bbox, west: -180 },
             density: options.density,
             signal: options.signal,
@@ -2792,9 +2794,9 @@ export function CesiumViewer() {
 
       const data = await fetchWindVectorData({
         apiBaseUrl: apiBaseUrl ?? '',
-        runTimeKey: DEFAULT_TIME_KEY,
+        runTimeKey,
         timeKey,
-        level: 'sfc',
+        level: levelKey,
         bbox: options.bbox,
         density: options.density,
         signal: options.signal,
@@ -2842,7 +2844,7 @@ export function CesiumViewer() {
       });
 
       const normalizedApiBaseUrl = apiBaseUrl.trim().replace(/\/+$/, '');
-      const viewKey = `${normalizedApiBaseUrl}:${timeKey}:${density}:${bbox.west},${bbox.south},${bbox.east},${bbox.north}`;
+      const viewKey = `${normalizedApiBaseUrl}:${runTimeKey}:${timeKey}:${levelKey}:${density}:${bbox.west},${bbox.south},${bbox.east},${bbox.north}`;
       const styleKey = `${windLayerConfig.opacity}:${windVisible}:${lowModeEnabled}`;
 
       if (windViewKeyRef.current !== viewKey) {
@@ -2962,7 +2964,7 @@ export function CesiumViewer() {
       clearTimer();
       cancelInFlight();
     };
-  }, [apiBaseUrl, lowModeEnabled, timeKey, viewer, windLayerConfig]);
+  }, [apiBaseUrl, levelKey, lowModeEnabled, runTimeKey, timeKey, viewer, windLayerConfig]);
 
   useEffect(() => {
     if (!viewer) return;
@@ -3102,6 +3104,7 @@ export function CesiumViewer() {
         id: config.id,
         apiBaseUrl,
         timeKey,
+        levelKey,
         variable: config.variable,
         opacity: config.opacity,
         visible: config.visible,
@@ -3121,7 +3124,7 @@ export function CesiumViewer() {
       layer.destroy();
       existing.delete(id);
     }
-  }, [apiBaseUrl, layers, timeKey, viewer]);
+  }, [apiBaseUrl, layers, levelKey, timeKey, viewer]);
 
   useEffect(() => {
     if (!viewer) return;

--- a/apps/web/src/state/time.test.tsx
+++ b/apps/web/src/state/time.test.tsx
@@ -1,7 +1,13 @@
 import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { DEFAULT_TIME_KEY, useTimeStore } from './time';
+import {
+  DEFAULT_LEVEL_KEY,
+  DEFAULT_RUN_TIME_KEY,
+  DEFAULT_TIME_KEY,
+  DEFAULT_VALID_TIME_KEY,
+  useTimeStore,
+} from './time';
 
 function Harness() {
   const timeKey = useTimeStore((state) => state.timeKey);
@@ -10,7 +16,19 @@ function Harness() {
 
 describe('useTimeStore', () => {
   beforeEach(() => {
-    useTimeStore.setState({ timeKey: DEFAULT_TIME_KEY });
+    useTimeStore.setState({
+      runTimeKey: DEFAULT_RUN_TIME_KEY,
+      validTimeKey: DEFAULT_VALID_TIME_KEY,
+      levelKey: DEFAULT_LEVEL_KEY,
+    });
+  });
+
+  it('defaults validTimeKey to +3h', () => {
+    const state = useTimeStore.getState();
+    expect(state.runTimeKey).toBe(DEFAULT_RUN_TIME_KEY);
+    expect(state.validTimeKey).toBe(DEFAULT_VALID_TIME_KEY);
+    expect(state.levelKey).toBe(DEFAULT_LEVEL_KEY);
+    expect(state.timeKey).toBe(DEFAULT_TIME_KEY);
   });
 
   it('updates subscribers when timeKey changes', () => {

--- a/apps/web/src/state/time.ts
+++ b/apps/web/src/state/time.ts
@@ -1,9 +1,34 @@
 import { useSyncExternalStore } from 'react';
 
-export const DEFAULT_TIME_KEY = '2025-12-22T00:00:00Z';
+export const DEFAULT_RUN_TIME_KEY = '2025-12-22T00:00:00Z';
+export const DEFAULT_LEVEL_KEY = 'sfc';
+
+function toUtcIsoNoMillis(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function addHoursUtcIso(baseUtcIso: string, hours: number): string {
+  const base = new Date(baseUtcIso);
+  if (Number.isNaN(base.getTime())) return baseUtcIso;
+  return toUtcIsoNoMillis(new Date(base.getTime() + hours * 60 * 60 * 1000));
+}
+
+export const DEFAULT_VALID_TIME_KEY = addHoursUtcIso(DEFAULT_RUN_TIME_KEY, 3);
+
+// Backwards-compatible alias: historically `timeKey` was the only concept of time.
+// It now maps to ECMWF valid time by default.
+export const DEFAULT_TIME_KEY = DEFAULT_VALID_TIME_KEY;
 
 type TimeState = {
+  runTimeKey: string;
+  validTimeKey: string;
+  levelKey: string;
+  // Backwards-compatible alias for `validTimeKey`.
   timeKey: string;
+  setRunTimeKey: (runTimeKey: string) => void;
+  setValidTimeKey: (validTimeKey: string) => void;
+  setLevelKey: (levelKey: string) => void;
+  // Backwards-compatible alias for `setValidTimeKey`.
   setTimeKey: (timeKey: string) => void;
 };
 
@@ -15,32 +40,85 @@ function notify() {
   for (const listener of listeners) listener();
 }
 
-let timeKey = DEFAULT_TIME_KEY;
+let runTimeKey = DEFAULT_RUN_TIME_KEY;
+let validTimeKey = DEFAULT_VALID_TIME_KEY;
+let levelKey = DEFAULT_LEVEL_KEY;
 
 function normalizeTimeKey(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(/\.\d{3}Z$/, 'Z');
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeLevelKey(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
 }
 
-const setTimeKey: TimeState['setTimeKey'] = (next) => {
+const setRunTimeKey: TimeState['setRunTimeKey'] = (next) => {
   const normalized = normalizeTimeKey(next);
   if (!normalized) return;
-  if (timeKey === normalized) return;
-  timeKey = normalized;
+  if (runTimeKey === normalized) return;
+  runTimeKey = normalized;
   notify();
 };
 
+const setValidTimeKey: TimeState['setValidTimeKey'] = (next) => {
+  const normalized = normalizeTimeKey(next);
+  if (!normalized) return;
+  if (validTimeKey === normalized) return;
+  validTimeKey = normalized;
+  notify();
+};
+
+const setLevelKey: TimeState['setLevelKey'] = (next) => {
+  const normalized = normalizeLevelKey(next);
+  if (!normalized) return;
+  if (levelKey === normalized) return;
+  levelKey = normalized;
+  notify();
+};
+
+const setTimeKey: TimeState['setTimeKey'] = (next) => {
+  setValidTimeKey(next);
+};
+
 function getState(): TimeState {
-  return { timeKey, setTimeKey };
+  return {
+    runTimeKey,
+    validTimeKey,
+    levelKey,
+    timeKey: validTimeKey,
+    setRunTimeKey,
+    setValidTimeKey,
+    setLevelKey,
+    setTimeKey,
+  };
 }
 
-function setState(partial: Partial<Pick<TimeState, 'timeKey'>>) {
-  const normalized = normalizeTimeKey(partial.timeKey);
-  if (!normalized) return;
-  if (timeKey === normalized) return;
-  timeKey = normalized;
-  notify();
+function setState(
+  partial: Partial<Pick<TimeState, 'runTimeKey' | 'validTimeKey' | 'levelKey' | 'timeKey'>>,
+) {
+  const nextRun = normalizeTimeKey(partial.runTimeKey);
+  const nextValid = normalizeTimeKey(partial.validTimeKey ?? partial.timeKey);
+  const nextLevel = normalizeLevelKey(partial.levelKey);
+
+  let changed = false;
+  if (nextRun && runTimeKey !== nextRun) {
+    runTimeKey = nextRun;
+    changed = true;
+  }
+  if (nextValid && validTimeKey !== nextValid) {
+    validTimeKey = nextValid;
+    changed = true;
+  }
+  if (nextLevel && levelKey !== nextLevel) {
+    levelKey = nextLevel;
+    changed = true;
+  }
+
+  if (changed) notify();
 }
 
 function subscribe(listener: Listener) {


### PR DESCRIPTION
## 概述

实现 Issue #336，支持 EC 预报的多时次（0-240h 非等间隔）和多高度层选择，修复降水和风图层显示问题。

## 改动内容

### 前端
- **TimelineBar**: 调用 catalog API 获取 run 和 valid_time 列表，替代硬编码 24 小时帧
- **time.ts**: 分离 `runTimeKey`/`validTimeKey`/`levelKey`，保持向后兼容（CLDAS 不受影响）
- **InfoPanel**: 增加高度层下拉选择 UI，选项来自 catalog API
- **TemperatureLayer**: level 参数从 store 传递到 URL
- **CesiumViewer**: 风请求参数改为来自选中的 `runTimeKey + validTimeKey + levelKey`
- **新增 ecmwfCatalogApi.ts**: 封装 ECMWF catalog API 调用

### 后端
- **catalog.py**: `/catalog/ecmwf/runs/{run}/vars` 的 `levels` 改为从 DB `ecmwf_assets` 动态获取

### Data Pipeline
- **generate_ecmwf_forecast_assets.py**: 默认生成 0-240h 全量数据（53 时次），支持标准 EC 非等间隔采样

## 测试

- [x] `pnpm test` 通过
- [x] `pnpm typecheck` 通过
- [x] `pytest -q apps/api/tests` 通过

## 待后续补充

- [ ] 多高度层（850/700/500/300hPa）GRIB 解码和瓦片生成
- [ ] 风 datacube 多高度层支持

## 相关 Issue

Closes #336