### PR TITLE
feat(data-pipeline): add multi-level tile generation with humidity support

### DIFF
--- a/services/data-pipeline/scripts/batch_generate_ecmwf_tiles.py
+++ b/services/data-pipeline/scripts/batch_generate_ecmwf_tiles.py
@@ -323,7 +323,9 @@ def main(argv: Iterable[str] | None = None) -> int:
 
     resolved_formats = _parse_formats(tuple(args.formats)) or DEFAULT_TILE_FORMATS
     resolved_levels = _parse_levels(tuple(args.levels)) or (str(args.level),)
-    surface_levels = tuple(level for level in resolved_levels if _is_surface_level(level))
+    surface_levels = tuple(
+        level for level in resolved_levels if _is_surface_level(level)
+    )
     isobaric_levels = tuple(
         level for level in resolved_levels if not _is_surface_level(level)
     )
@@ -428,7 +430,9 @@ def main(argv: Iterable[str] | None = None) -> int:
                     )
                 else:
                     tp_slice = ds_surface["tp"].isel(time=0, level=0)
-                    current_tp = np.asarray(tp_slice.values).astype(np.float32, copy=False)
+                    current_tp = np.asarray(tp_slice.values).astype(
+                        np.float32, copy=False
+                    )
                     current_time = np.asarray(ds_surface["time"].values)[0].astype(
                         "datetime64[s]"
                     )
@@ -445,7 +449,9 @@ def main(argv: Iterable[str] | None = None) -> int:
                             if candidate_hours > 0:
                                 interval_hours = candidate_hours
                         prev_tp = np.zeros_like(current_tp, dtype=np.float32)
-                        prev_time = current_time - np.timedelta64(int(interval_hours), "h")
+                        prev_time = current_time - np.timedelta64(
+                            int(interval_hours), "h"
+                        )
 
                     ds_tp = xr.Dataset(
                         {
@@ -454,7 +460,11 @@ def main(argv: Iterable[str] | None = None) -> int:
                                 np.stack([prev_tp, current_tp], axis=0),
                             )
                         },
-                        coords={"time": [prev_time, current_time], "lat": lat, "lon": lon},
+                        coords={
+                            "time": [prev_time, current_time],
+                            "lat": lat,
+                            "lon": lon,
+                        },
                     )
                     cube_tp = DataCube.from_dataset(ds_tp)
                     try:
@@ -488,11 +498,7 @@ def main(argv: Iterable[str] | None = None) -> int:
                     previous_time = current_time
 
             wants_isobaric_layers = any((bool(args.temperature), bool(args.wind_speed)))
-            if (
-                wants_isobaric
-                and cube_isobaric is not None
-                and wants_isobaric_layers
-            ):
+            if wants_isobaric and cube_isobaric is not None and wants_isobaric_layers:
                 for level in isobaric_levels:
                     results = generate_ecmwf_raster_tiles(
                         cube_isobaric,

--- a/services/data-pipeline/scripts/batch_generate_multilevel_tiles.py
+++ b/services/data-pipeline/scripts/batch_generate_multilevel_tiles.py
@@ -329,7 +329,9 @@ def main(argv: Iterable[str] | None = None) -> int:
 
     resolved_formats = _parse_formats(tuple(args.formats)) or DEFAULT_TILE_FORMATS
     resolved_levels = _parse_levels(tuple(args.levels))
-    surface_levels = tuple(level for level in resolved_levels if _is_surface_level(level))
+    surface_levels = tuple(
+        level for level in resolved_levels if _is_surface_level(level)
+    )
     isobaric_levels = tuple(
         level for level in resolved_levels if not _is_surface_level(level)
     )
@@ -443,8 +445,12 @@ def main(argv: Iterable[str] | None = None) -> int:
                         precipitation=False,
                         wind_speed=True,
                         wind_speed_opacity=float(args.wind_speed_opacity),
-                        min_zoom=int(args.min_zoom) if args.min_zoom is not None else None,
-                        max_zoom=int(args.max_zoom) if args.max_zoom is not None else None,
+                        min_zoom=int(args.min_zoom)
+                        if args.min_zoom is not None
+                        else None,
+                        max_zoom=int(args.max_zoom)
+                        if args.max_zoom is not None
+                        else None,
                         tile_size=int(args.tile_size)
                         if args.tile_size is not None
                         else None,
@@ -453,7 +459,9 @@ def main(argv: Iterable[str] | None = None) -> int:
                     for result in results:
                         print(
                             " ",
-                            json.dumps(result.__dict__, ensure_ascii=False, default=str),
+                            json.dumps(
+                                result.__dict__, ensure_ascii=False, default=str
+                            ),
                         )
 
             if (
@@ -483,7 +491,9 @@ def main(argv: Iterable[str] | None = None) -> int:
                         )
                         print(
                             " ",
-                            json.dumps(result.__dict__, ensure_ascii=False, default=str),
+                            json.dumps(
+                                result.__dict__, ensure_ascii=False, default=str
+                            ),
                         )
                     except HumidityTilingError as exc:
                         print(

--- a/services/data-pipeline/src/datacube/decoder.py
+++ b/services/data-pipeline/src/datacube/decoder.py
@@ -175,8 +175,7 @@ def decode_grib(
         subset_key = "isobaric_rh"
     if subset_key not in {"surface", "isobaric", "isobaric_rh"}:
         raise ValueError(
-            "subset must be one of: surface, isobaric, humidity "
-            f"(got {subset!r})"
+            f"subset must be one of: surface, isobaric, humidity (got {subset!r})"
         )
 
     path = Path(source_path)
@@ -281,8 +280,12 @@ def decode_grib(
                 }
             )
             if wind_u is not None and wind_v is not None:
-                subsets.append(_ensure_time_dim(_keep_single_var(wind_u, preferred="u")))
-                subsets.append(_ensure_time_dim(_keep_single_var(wind_v, preferred="v")))
+                subsets.append(
+                    _ensure_time_dim(_keep_single_var(wind_u, preferred="u"))
+                )
+                subsets.append(
+                    _ensure_time_dim(_keep_single_var(wind_v, preferred="v"))
+                )
             else:
                 if wind_u is not None:
                     _close_quietly(wind_u)

--- a/services/data-pipeline/src/datacube/decoder.py
+++ b/services/data-pipeline/src/datacube/decoder.py
@@ -54,7 +54,21 @@ def decode_grib(
     source_path: Union[str, Path],
     *,
     engine: str = "cfgrib",
+    subset: str = "surface",
 ) -> DataCube:
+    """Decode a GRIB file into a normalized DataCube.
+
+    Notes
+    -----
+    ECMWF forecast GRIBs in this repository commonly bundle multiple grids:
+
+    - Surface fields on a global grid (e.g. t2m/tcc/tp/10u/10v)
+    - Pressure-level fields on a regional grid (e.g. t/u/v on isobaricInhPa)
+
+    A single DataCube must have a single lat/lon grid, so callers may request a
+    specific subset to decode.
+    """
+
     def _open_cfgrib_subset(*, filter_by_keys: dict[str, Any]) -> Optional[xr.Dataset]:
         """Open a GRIB subset using cfgrib filter_by_keys.
 
@@ -154,6 +168,17 @@ def decode_grib(
         except Exception:  # noqa: BLE001
             pass
 
+    subset_key = str(subset or "").strip().lower()
+    if subset_key in {"sfc"}:
+        subset_key = "surface"
+    if subset_key in {"rh", "humidity", "isobaric_rh", "isobaric-humidity"}:
+        subset_key = "isobaric_rh"
+    if subset_key not in {"surface", "isobaric", "isobaric_rh"}:
+        raise ValueError(
+            "subset must be one of: surface, isobaric, humidity "
+            f"(got {subset!r})"
+        )
+
     path = Path(source_path)
     try:
         if engine != "cfgrib":
@@ -162,75 +187,131 @@ def decode_grib(
 
         subsets: list[xr.Dataset] = []
 
-        temperature: Optional[xr.Dataset] = None
-        for keys in ({"shortName": "2t"}, {"shortName": "t2m"}):
-            candidate = _open_cfgrib_subset(filter_by_keys=keys)
-            if candidate is None:
-                continue
-            temperature = _keep_single_var(candidate, preferred="t2m")
-            break
-        if temperature is not None:
-            subsets.append(_ensure_time_dim(temperature))
+        if subset_key == "surface":
+            temperature: Optional[xr.Dataset] = None
+            for keys in ({"shortName": "2t"}, {"shortName": "t2m"}):
+                candidate = _open_cfgrib_subset(filter_by_keys=keys)
+                if candidate is None:
+                    continue
+                temperature = _keep_single_var(candidate, preferred="t2m")
+                break
+            if temperature is not None:
+                subsets.append(_ensure_time_dim(temperature))
 
-        cloud = _open_cfgrib_subset(filter_by_keys={"shortName": "tcc"})
-        if cloud is not None:
-            subsets.append(_ensure_time_dim(_keep_single_var(cloud, preferred="tcc")))
+            cloud = _open_cfgrib_subset(filter_by_keys={"shortName": "tcc"})
+            if cloud is not None:
+                subsets.append(
+                    _ensure_time_dim(_keep_single_var(cloud, preferred="tcc"))
+                )
 
-        precip = _open_cfgrib_subset(filter_by_keys={"shortName": "tp"})
-        if precip is not None:
-            subsets.append(_ensure_time_dim(_keep_single_var(precip, preferred="tp")))
+            precip = _open_cfgrib_subset(filter_by_keys={"shortName": "tp"})
+            if precip is not None:
+                subsets.append(
+                    _ensure_time_dim(_keep_single_var(precip, preferred="tp"))
+                )
 
-        precip_type = _open_cfgrib_subset(filter_by_keys={"shortName": "ptype"})
-        if precip_type is not None:
-            subsets.append(
-                _ensure_time_dim(_keep_single_var(precip_type, preferred="ptype"))
+            precip_type = _open_cfgrib_subset(filter_by_keys={"shortName": "ptype"})
+            if precip_type is not None:
+                subsets.append(
+                    _ensure_time_dim(_keep_single_var(precip_type, preferred="ptype"))
+                )
+
+            wind_u10 = _open_cfgrib_subset(filter_by_keys={"shortName": "10u"})
+            wind_v10 = _open_cfgrib_subset(filter_by_keys={"shortName": "10v"})
+            if wind_u10 is not None and wind_v10 is not None:
+                u10 = _ensure_time_dim(_keep_single_var(wind_u10, preferred="u10"))
+                v10 = _ensure_time_dim(_keep_single_var(wind_v10, preferred="v10"))
+                u10 = u10.rename_vars({"u10": "eastward_wind_10m"})
+                v10 = v10.rename_vars({"v10": "northward_wind_10m"})
+                subsets.extend([u10, v10])
+            else:
+                if wind_u10 is not None:
+                    _close_quietly(wind_u10)
+                if wind_v10 is not None:
+                    _close_quietly(wind_v10)
+
+                wind_u = _open_cfgrib_subset(
+                    filter_by_keys={
+                        "shortName": "u",
+                        "typeOfLevel": "heightAboveGround",
+                        "level": 10,
+                    }
+                )
+                wind_v = _open_cfgrib_subset(
+                    filter_by_keys={
+                        "shortName": "v",
+                        "typeOfLevel": "heightAboveGround",
+                        "level": 10,
+                    }
+                )
+                if wind_u is not None and wind_v is not None:
+                    subsets.append(
+                        _ensure_time_dim(_keep_single_var(wind_u, preferred="u"))
+                    )
+                    subsets.append(
+                        _ensure_time_dim(_keep_single_var(wind_v, preferred="v"))
+                    )
+                else:
+                    if wind_u is not None:
+                        _close_quietly(wind_u)
+                    if wind_v is not None:
+                        _close_quietly(wind_v)
+        elif subset_key == "isobaric":
+            temperature_pl = _open_cfgrib_subset(
+                filter_by_keys={
+                    "shortName": "t",
+                    "typeOfLevel": "isobaricInhPa",
+                }
             )
-
-        wind_u10 = _open_cfgrib_subset(filter_by_keys={"shortName": "10u"})
-        wind_v10 = _open_cfgrib_subset(filter_by_keys={"shortName": "10v"})
-        if wind_u10 is not None and wind_v10 is not None:
-            u10 = _ensure_time_dim(_keep_single_var(wind_u10, preferred="u10"))
-            v10 = _ensure_time_dim(_keep_single_var(wind_v10, preferred="v10"))
-            u10 = u10.rename_vars({"u10": "eastward_wind_10m"})
-            v10 = v10.rename_vars({"v10": "northward_wind_10m"})
-            subsets.extend([u10, v10])
-        else:
-            if wind_u10 is not None:
-                _close_quietly(wind_u10)
-            if wind_v10 is not None:
-                _close_quietly(wind_v10)
+            if temperature_pl is not None:
+                subsets.append(
+                    _ensure_time_dim(_keep_single_var(temperature_pl, preferred="t"))
+                )
 
             wind_u = _open_cfgrib_subset(
                 filter_by_keys={
                     "shortName": "u",
-                    "typeOfLevel": "heightAboveGround",
-                    "level": 10,
+                    "typeOfLevel": "isobaricInhPa",
                 }
             )
             wind_v = _open_cfgrib_subset(
                 filter_by_keys={
                     "shortName": "v",
-                    "typeOfLevel": "heightAboveGround",
-                    "level": 10,
+                    "typeOfLevel": "isobaricInhPa",
                 }
             )
             if wind_u is not None and wind_v is not None:
-                subsets.append(
-                    _ensure_time_dim(_keep_single_var(wind_u, preferred="u"))
-                )
-                subsets.append(
-                    _ensure_time_dim(_keep_single_var(wind_v, preferred="v"))
-                )
+                subsets.append(_ensure_time_dim(_keep_single_var(wind_u, preferred="u")))
+                subsets.append(_ensure_time_dim(_keep_single_var(wind_v, preferred="v")))
             else:
                 if wind_u is not None:
                     _close_quietly(wind_u)
                 if wind_v is not None:
                     _close_quietly(wind_v)
+        else:
+            rh_pl = _open_cfgrib_subset(
+                filter_by_keys={
+                    "shortName": "r",
+                    "typeOfLevel": "isobaricInhPa",
+                }
+            )
+            if rh_pl is not None:
+                subsets.append(_ensure_time_dim(_keep_single_var(rh_pl, preferred="r")))
 
         if not subsets:
+            if subset_key == "surface":
+                raise DataCubeDecodeError(
+                    "Failed to decode GRIB: no supported surface variables found "
+                    "(expected t2m/2t, tcc, tp, ptype, 10u/10v or u/v)"
+                )
+            if subset_key == "isobaric":
+                raise DataCubeDecodeError(
+                    "Failed to decode GRIB: no supported isobaric variables found "
+                    "(expected t/u/v on isobaricInhPa)"
+                )
             raise DataCubeDecodeError(
-                "Failed to decode GRIB: no supported variables found "
-                "(expected t2m/2t, tcc, tp, ptype, 10u/10v or u/v)"
+                "Failed to decode GRIB: no supported humidity variables found "
+                "(expected r on isobaricInhPa)"
             )
 
         merged = xr.merge(

--- a/services/data-pipeline/src/tiles/generate.py
+++ b/services/data-pipeline/src/tiles/generate.py
@@ -105,6 +105,7 @@ def generate_ecmwf_raster_tiles(
     *,
     valid_time: object | None = None,
     level: object = "sfc",
+    temperature_variable: str | None = None,
     temperature: bool = True,
     cloud: bool = True,
     precipitation: bool = True,
@@ -127,7 +128,11 @@ def generate_ecmwf_raster_tiles(
     output_dir = Path(output_dir)
 
     if temperature:
-        generator = TemperatureTileGenerator(cube)
+        generator = (
+            TemperatureTileGenerator(cube)
+            if temperature_variable is None
+            else TemperatureTileGenerator(cube, variable=str(temperature_variable))
+        )
         try:
             results.append(
                 generator.generate(

--- a/services/data-pipeline/src/tiling/humidity_tiles.py
+++ b/services/data-pipeline/src/tiling/humidity_tiles.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final, Sequence
+
+import numpy as np
+import xarray as xr
+from PIL import Image
+
+from datacube.core import DataCube
+from derived.cloud_density import normalize_relative_humidity
+from tiling.cldas_tiles import (
+    _bilinear_sample,
+    _ensure_ascending_axis,
+    _normalize_longitudes,
+)
+from tiling.config import TilingConfig, get_tiling_config
+from tiling.epsg4326 import TileBounds, lat_to_tile_y, lon_to_tile_x, tile_bounds
+from tiling.tcc_tiles import tcc_rgba
+
+
+class HumidityTilingError(RuntimeError):
+    pass
+
+
+DEFAULT_HUMIDITY_LAYER: Final[str] = "ecmwf/humidity"
+DEFAULT_HUMIDITY_VARIABLE: Final[str] = "r"
+
+_LAYER_SEGMENT_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_]+$")
+_TIME_KEY_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9TZ-]+$")
+_LEVEL_KEY_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_-]+$")
+
+_SURFACE_LEVEL_ALIASES: Final[set[str]] = {"sfc", "surface"}
+
+SUPPORTED_TILE_FORMATS: Final[set[str]] = {"png", "webp"}
+
+
+def _validate_layer(value: str) -> str:
+    normalized = (value or "").strip().strip("/")
+    if normalized == "":
+        raise ValueError("layer must not be empty")
+
+    segments = normalized.split("/")
+    invalid_segments = [
+        segment
+        for segment in segments
+        if not segment or _LAYER_SEGMENT_RE.fullmatch(segment) is None
+    ]
+    if invalid_segments:
+        raise ValueError("layer contains unsafe characters")
+    return "/".join(segments)
+
+
+def _validate_time_key(value: str) -> str:
+    normalized = (value or "").strip()
+    if normalized == "":
+        raise ValueError("time_key must not be empty")
+    if _TIME_KEY_RE.fullmatch(normalized) is None:
+        raise ValueError("time_key contains unsafe characters")
+    return normalized
+
+
+def _validate_level_key(value: str) -> str:
+    normalized = (value or "").strip()
+    if normalized == "":
+        raise ValueError("level_key must not be empty")
+    if _LEVEL_KEY_RE.fullmatch(normalized) is None:
+        raise ValueError("level_key contains unsafe characters")
+    return normalized
+
+
+def _ensure_relative_to_base(*, base_dir: Path, path: Path, label: str) -> None:
+    if not path.is_relative_to(base_dir):
+        raise ValueError(f"{label} escapes output_dir")
+
+
+def _normalize_time_key(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _parse_time(value: object) -> datetime:
+    if isinstance(value, np.datetime64):
+        # DataCube stores time as UTC-naive datetime64; treat as UTC.
+        text = np.datetime_as_string(value.astype("datetime64[s]"), unit="s")
+        return datetime.fromisoformat(text).replace(tzinfo=timezone.utc)
+
+    if isinstance(value, datetime):
+        dt = value
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    raw = str(value or "").strip()
+    if raw == "":
+        raise ValueError("valid_time must not be empty")
+
+    candidate = raw
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    except ValueError:
+        try:
+            return datetime.strptime(raw, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+        except ValueError as exc:
+            raise ValueError(
+                "valid_time must be an ISO8601 timestamp or a tile version key"
+            ) from exc
+
+
+def _resolve_time_index(ds: xr.Dataset, valid_time: object) -> tuple[int, str]:
+    if "time" not in ds.coords:
+        raise HumidityTilingError("Dataset missing required coordinate: time")
+
+    values = np.asarray(ds["time"].values)
+    if values.size == 0:
+        raise HumidityTilingError("time coordinate is empty")
+
+    dt = _parse_time(valid_time)
+    key = _validate_time_key(_normalize_time_key(dt))
+
+    target = np.datetime64(dt.strftime("%Y-%m-%dT%H:%M:%S"))
+    matches = np.where(values.astype("datetime64[s]") == target)[0]
+    if matches.size == 0:
+        available = [
+            _normalize_time_key(_parse_time(item))
+            for item in values[: min(5, values.size)]
+        ]
+        raise HumidityTilingError(
+            f"valid_time not found in dataset: {dt.isoformat()} (sample={available})"
+        )
+    return int(matches[0]), key
+
+
+def _normalize_level_request(value: object) -> tuple[str, float | None]:
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized == "":
+            raise ValueError("level must not be empty")
+        lowered = normalized.lower()
+        if lowered in _SURFACE_LEVEL_ALIASES:
+            return "sfc", None
+        try:
+            stripped = re.sub(r"hpa$", "", lowered).strip()
+            numeric = float(stripped)
+        except ValueError as exc:
+            raise ValueError("level must be 'sfc' or a numeric pressure level") from exc
+        if not np.isfinite(numeric):
+            raise ValueError("level must be a finite number")
+        if numeric.is_integer():
+            level_key = str(int(numeric))
+        else:
+            level_key = str(numeric).replace(".", "p")
+        return _validate_level_key(level_key), numeric
+
+    if isinstance(value, (int, float, np.number)):
+        numeric = float(value)
+        if not np.isfinite(numeric):
+            raise ValueError("level must be a finite number")
+        if numeric.is_integer():
+            level_key = str(int(numeric))
+        else:
+            level_key = str(numeric).replace(".", "p")
+        return _validate_level_key(level_key), numeric
+
+    raise ValueError("level must be 'sfc' or a numeric pressure level")
+
+
+def _resolve_surface_level_index(levels: np.ndarray, attrs: dict) -> int:
+    units = str(attrs.get("units") or "").strip().lower()
+    long_name = str(attrs.get("long_name") or "").strip().lower()
+
+    if "surface" in long_name or units in {"1", ""}:
+        return 0
+
+    matches = np.where(
+        np.isclose(levels.astype(np.float64, copy=False), 0.0, atol=1e-3)
+    )[0]
+    if matches.size:
+        return int(matches[0])
+    raise HumidityTilingError("surface level requested but dataset has no surface level")
+
+
+def _resolve_level_index(ds: xr.Dataset, level: object) -> tuple[int, str]:
+    if "level" not in ds.coords:
+        raise HumidityTilingError("Dataset missing required coordinate: level")
+
+    levels = np.asarray(ds["level"].values)
+    if levels.size == 0:
+        raise HumidityTilingError("level coordinate is empty")
+
+    level_key, numeric = _normalize_level_request(level)
+    if level_key.lower() in _SURFACE_LEVEL_ALIASES or level_key == "sfc":
+        idx = _resolve_surface_level_index(levels, dict(ds["level"].attrs))
+        return idx, "sfc"
+
+    if numeric is None or not np.isfinite(numeric):
+        raise HumidityTilingError("Pressure level must be a finite number")
+
+    numeric_f = float(numeric)
+    matches = np.where(
+        np.isclose(levels.astype(np.float64, copy=False), numeric_f, atol=1e-3)
+    )[0]
+    if matches.size == 0:
+        available = [str(val) for val in levels[: min(5, levels.size)]]
+        raise HumidityTilingError(
+            f"level not found in dataset: {numeric_f} (sample={available})"
+        )
+
+    resolved = levels[int(matches[0])]
+    if np.isfinite(resolved) and float(resolved).is_integer():
+        level_key = str(int(float(resolved)))
+    else:
+        level_key = str(numeric_f).replace(".", "p")
+    return int(matches[0]), _validate_level_key(level_key)
+
+
+def _validate_tile_formats(formats: Sequence[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for fmt in formats:
+        f = (fmt or "").strip().lower()
+        if f == "":
+            continue
+        if f not in SUPPORTED_TILE_FORMATS:
+            raise ValueError(f"Unsupported tile format: {fmt!r}")
+        if f not in normalized:
+            normalized.append(f)
+    if not normalized:
+        raise ValueError("At least one tile format must be specified")
+    return tuple(normalized)
+
+
+def _save_tile_image(img: Image.Image, path: Path) -> None:
+    suffix = path.suffix.lower()
+    if suffix == ".png":
+        img.save(path, format="PNG", optimize=True)
+        return
+    if suffix == ".webp":
+        img.save(path, format="WEBP", lossless=True, method=6)
+        return
+    raise ValueError(f"Unsupported tile file extension: {path.suffix}")
+
+
+def _validate_opacity(value: float) -> float:
+    opacity = float(value)
+    if not np.isfinite(opacity) or opacity < 0.0 or opacity > 1.0:
+        raise ValueError("opacity must be between 0 and 1")
+    return opacity
+
+
+@dataclass(frozen=True)
+class HumidityTileGenerationResult:
+    layer: str
+    variable: str
+    time: str
+    level: str
+    opacity: float
+    output_dir: Path
+    min_zoom: int
+    max_zoom: int
+    formats: tuple[str, ...]
+    tiles_written: int
+
+
+class HumidityTileGenerator:
+    def __init__(
+        self,
+        cube: DataCube,
+        *,
+        variable: str = DEFAULT_HUMIDITY_VARIABLE,
+        layer: str = DEFAULT_HUMIDITY_LAYER,
+    ) -> None:
+        self._cube = cube
+        self._variable = (variable or "").strip()
+        if self._variable == "":
+            raise ValueError("variable must not be empty")
+        self._layer = _validate_layer(layer)
+
+    @classmethod
+    def from_dataset(
+        cls,
+        ds: xr.Dataset,
+        *,
+        variable: str = DEFAULT_HUMIDITY_VARIABLE,
+        layer: str = DEFAULT_HUMIDITY_LAYER,
+    ) -> "HumidityTileGenerator":
+        return cls(DataCube.from_dataset(ds), variable=variable, layer=layer)
+
+    @property
+    def variable(self) -> str:
+        return self._variable
+
+    @property
+    def layer(self) -> str:
+        return self._layer
+
+    def _extract_grid(
+        self, *, time_index: int, level_index: int
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        ds = self._cube.dataset
+        if self._variable not in ds.data_vars:
+            raise HumidityTilingError(
+                f"Variable {self._variable!r} not found; available={list(ds.data_vars)}"
+            )
+
+        da = ds[self._variable]
+        if "time" not in da.dims:
+            raise HumidityTilingError("humidity variable missing required dim: time")
+        if "level" not in da.dims:
+            raise HumidityTilingError("humidity variable missing required dim: level")
+
+        time_count = int(da.sizes.get("time", 0))
+        level_count = int(da.sizes.get("level", 0))
+        if time_count == 0:
+            raise HumidityTilingError("time dimension is empty")
+        if level_count == 0:
+            raise HumidityTilingError("level dimension is empty")
+        if time_index < 0 or time_index >= time_count:
+            raise HumidityTilingError("time_index is out of range")
+        if level_index < 0 or level_index >= level_count:
+            raise HumidityTilingError("level_index is out of range")
+
+        slice_da = da.isel(time=int(time_index), level=int(level_index))
+        if set(slice_da.dims) != {"lat", "lon"}:
+            raise HumidityTilingError(
+                f"Expected data dims {{'lat','lon'}}, got {list(slice_da.dims)}"
+            )
+        slice_da = slice_da.transpose("lat", "lon")
+
+        lat = np.asarray(ds["lat"].values)
+        lon = np.asarray(ds["lon"].values)
+        grid = np.asarray(normalize_relative_humidity(slice_da).values).astype(
+            np.float32, copy=False
+        )
+
+        lat, grid = _ensure_ascending_axis(lat, grid, axis=0)
+        lon, grid = _ensure_ascending_axis(lon, grid, axis=1)
+        lon, grid = _normalize_longitudes(lon, grid)
+
+        if lat.size != grid.shape[0] or lon.size != grid.shape[1]:
+            raise HumidityTilingError("lat/lon coordinates do not match grid shape")
+
+        return (
+            lat.astype(np.float64, copy=False),
+            lon.astype(np.float64, copy=False),
+            grid,
+        )
+
+    def _render_tile_array(
+        self,
+        *,
+        zoom: int,
+        x: int,
+        y: int,
+        tile_size: int,
+        lat: np.ndarray,
+        lon: np.ndarray,
+        grid: np.ndarray,
+        opacity: float,
+    ) -> np.ndarray:
+        if tile_size <= 0:
+            raise ValueError("tile_size must be > 0")
+
+        bounds: TileBounds = tile_bounds(zoom, x, y)
+
+        cols = (np.arange(tile_size, dtype=np.float64) + 0.5) / tile_size
+        rows = (np.arange(tile_size, dtype=np.float64) + 0.5) / tile_size
+
+        lon_px = bounds.west + cols * (bounds.east - bounds.west)
+        lat_px = bounds.north - rows * (bounds.north - bounds.south)
+
+        sampled = _bilinear_sample(
+            lat, lon, grid, lat_query=lat_px.astype(np.float64), lon_query=lon_px
+        )
+        return tcc_rgba(sampled, opacity=opacity)
+
+    @staticmethod
+    def _validate_config(config: TilingConfig) -> None:
+        if config.crs != "EPSG:4326":
+            raise ValueError(
+                f"Unsupported tiling CRS={config.crs!r}; expected EPSG:4326"
+            )
+
+    @staticmethod
+    def _validate_zoom_range(
+        *, min_zoom: int, max_zoom: int, config: TilingConfig
+    ) -> None:
+        if min_zoom < 0 or max_zoom < 0 or max_zoom < min_zoom:
+            raise ValueError("Invalid zoom range")
+
+        global_range = config.global_
+        event_range = config.event
+
+        if min_zoom < global_range.min_zoom:
+            raise ValueError(
+                f"Requested min_zoom={min_zoom} below configured global min_zoom={global_range.min_zoom}"
+            )
+        if max_zoom > event_range.max_zoom:
+            raise ValueError(
+                f"Requested max_zoom={max_zoom} exceeds configured max_zoom={event_range.max_zoom}"
+            )
+
+        in_global = (
+            min_zoom >= global_range.min_zoom and max_zoom <= global_range.max_zoom
+        )
+        in_event = min_zoom >= event_range.min_zoom and max_zoom <= event_range.max_zoom
+        if not (in_global or in_event):
+            raise ValueError(
+                "Requested zoom range must fall entirely within configured "
+                f"global={global_range.min_zoom}–{global_range.max_zoom} "
+                f"or event={event_range.min_zoom}–{event_range.max_zoom}"
+            )
+
+    def render_tile(
+        self,
+        *,
+        zoom: int,
+        x: int,
+        y: int,
+        valid_time: object,
+        level: object,
+        tile_size: int | None = None,
+        opacity: float = 1.0,
+    ) -> Image.Image:
+        ds = self._cube.dataset
+        time_index, _ = _resolve_time_index(ds, valid_time)
+        level_index, _ = _resolve_level_index(ds, level)
+
+        config = get_tiling_config()
+        self._validate_config(config)
+
+        lat, lon, grid = self._extract_grid(
+            time_index=time_index, level_index=level_index
+        )
+        resolved_tile_size = int(config.tile_size if tile_size is None else tile_size)
+        self._validate_zoom_range(min_zoom=int(zoom), max_zoom=int(zoom), config=config)
+        rgba = self._render_tile_array(
+            zoom=int(zoom),
+            x=int(x),
+            y=int(y),
+            tile_size=resolved_tile_size,
+            lat=lat,
+            lon=lon,
+            grid=grid,
+            opacity=_validate_opacity(opacity),
+        )
+        return Image.fromarray(rgba)
+
+    def generate(
+        self,
+        output_dir: str | Path,
+        *,
+        valid_time: object,
+        level: object,
+        opacity: float = 1.0,
+        min_zoom: int | None = None,
+        max_zoom: int | None = None,
+        tile_size: int | None = None,
+        formats: Sequence[str] = ("png", "webp"),
+    ) -> HumidityTileGenerationResult:
+        ds = self._cube.dataset
+        time_index, time_key = _resolve_time_index(ds, valid_time)
+        level_index, level_key = _resolve_level_index(ds, level)
+
+        resolved_formats = _validate_tile_formats(formats)
+        resolved_opacity = _validate_opacity(opacity)
+
+        config = get_tiling_config()
+        self._validate_config(config)
+
+        resolved_min_zoom: int
+        resolved_max_zoom: int
+        if min_zoom is None and max_zoom is None:
+            resolved_min_zoom = int(config.global_.min_zoom)
+            resolved_max_zoom = int(config.global_.max_zoom)
+        else:
+            resolved_min_zoom = int(max_zoom if min_zoom is None else min_zoom)
+            resolved_max_zoom = int(min_zoom if max_zoom is None else max_zoom)
+
+        resolved_tile_size = int(config.tile_size if tile_size is None else tile_size)
+
+        self._validate_zoom_range(
+            min_zoom=resolved_min_zoom, max_zoom=resolved_max_zoom, config=config
+        )
+
+        lat, lon, grid = self._extract_grid(
+            time_index=time_index, level_index=level_index
+        )
+        lat_min = float(np.nanmin(lat))
+        lat_max = float(np.nanmax(lat))
+        lon_min = float(np.nanmin(lon))
+        lon_max = float(np.nanmax(lon))
+
+        base = Path(output_dir).resolve()
+        layer_dir = (base / self._layer).resolve()
+        _ensure_relative_to_base(base_dir=base, path=layer_dir, label="layer")
+
+        tiles_root = (layer_dir / time_key / level_key).resolve()
+        _ensure_relative_to_base(base_dir=base, path=tiles_root, label="time_key")
+        tiles_root.mkdir(parents=True, exist_ok=True)
+
+        tiles_written = 0
+        for zoom in range(resolved_min_zoom, resolved_max_zoom + 1):
+            x0 = lon_to_tile_x(lon_min, zoom)
+            x1 = lon_to_tile_x(lon_max, zoom)
+            y0 = lat_to_tile_y(lat_max, zoom)
+            y1 = lat_to_tile_y(lat_min, zoom)
+
+            for x in range(x0, x1 + 1):
+                x_dir = tiles_root / str(zoom) / str(x)
+                x_dir.mkdir(parents=True, exist_ok=True)
+                for y in range(y0, y1 + 1):
+                    rgba = self._render_tile_array(
+                        zoom=zoom,
+                        x=x,
+                        y=y,
+                        tile_size=resolved_tile_size,
+                        lat=lat,
+                        lon=lon,
+                        grid=grid,
+                        opacity=resolved_opacity,
+                    )
+                    img = Image.fromarray(rgba)
+                    for fmt in resolved_formats:
+                        target = x_dir / f"{y}.{fmt}"
+                        _save_tile_image(img, target)
+                        tiles_written += 1
+
+        return HumidityTileGenerationResult(
+            layer=self._layer,
+            variable=self._variable,
+            time=time_key,
+            level=level_key,
+            opacity=resolved_opacity,
+            output_dir=layer_dir,
+            min_zoom=resolved_min_zoom,
+            max_zoom=resolved_max_zoom,
+            formats=resolved_formats,
+            tiles_written=tiles_written,
+        )
+

--- a/services/data-pipeline/src/tiling/humidity_tiles.py
+++ b/services/data-pipeline/src/tiling/humidity_tiles.py
@@ -184,7 +184,9 @@ def _resolve_surface_level_index(levels: np.ndarray, attrs: dict) -> int:
     )[0]
     if matches.size:
         return int(matches[0])
-    raise HumidityTilingError("surface level requested but dataset has no surface level")
+    raise HumidityTilingError(
+        "surface level requested but dataset has no surface level"
+    )
 
 
 def _resolve_level_index(ds: xr.Dataset, level: object) -> tuple[int, str]:
@@ -544,4 +546,3 @@ class HumidityTileGenerator:
             formats=resolved_formats,
             tiles_written=tiles_written,
         )
-

--- a/services/data-pipeline/tests/test_batch_generate_multilevel_tiles.py
+++ b/services/data-pipeline/tests/test_batch_generate_multilevel_tiles.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _load_script_module(monkeypatch: pytest.MonkeyPatch):
+    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    monkeypatch.syspath_prepend(str(scripts_dir))
+    import batch_generate_multilevel_tiles as script  # noqa: E402
+
+    return script
+
+
+def test_parse_formats_dedupes_and_lowercases(monkeypatch: pytest.MonkeyPatch) -> None:
+    script = _load_script_module(monkeypatch)
+    assert script._parse_formats([" PNG,webp", "webp", "", "png"]) == ("png", "webp")
+
+
+def test_parse_levels_dedupes_and_ignores_blanks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    script = _load_script_module(monkeypatch)
+    assert script._parse_levels(["", "  ", "850", "850", " 850 "]) == ("850",)
+
+
+def test_is_surface_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    script = _load_script_module(monkeypatch)
+    assert script._is_surface_level("sfc") is True
+    assert script._is_surface_level(" surface ") is True
+    assert script._is_surface_level("850") is False
+
+
+def test_message_valid_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    script = _load_script_module(monkeypatch)
+    dt = script._message_valid_time({"validityDate": 20260101, "validityTime": 300})
+    assert dt.isoformat() == "2026-01-01T03:00:00+00:00"
+
+    with pytest.raises(ValueError, match="validityDate"):
+        script._message_valid_time({"validityTime": 0})
+
+
+def test_expand_inputs_glob(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    script = _load_script_module(monkeypatch)
+    (tmp_path / "a.grib").write_bytes(b"fake")
+    (tmp_path / "b.grib").write_bytes(b"fake")
+
+    out = script._expand_inputs([str(tmp_path / "*.grib")])
+    assert [path.name for path in out] == ["a.grib", "b.grib"]

--- a/services/data-pipeline/tests/test_datacube.py
+++ b/services/data-pipeline/tests/test_datacube.py
@@ -282,7 +282,9 @@ def test_decode_grib_filters_surface_variables(monkeypatch: pytest.MonkeyPatch) 
     assert all(call.get("engine") == "cfgrib" for call in calls)
 
 
-def test_decode_grib_filters_humidity_variables(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_decode_grib_filters_humidity_variables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from datacube.decoder import decode_grib
 
     time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")

--- a/services/data-pipeline/tests/test_humidity_tiling.py
+++ b/services/data-pipeline/tests/test_humidity_tiling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
@@ -8,14 +9,16 @@ import xarray as xr
 from PIL import Image
 
 
-def _write_test_config_dir(config_dir: Path, *, tile_size: int = 8) -> None:
+def _write_test_config_dir(
+    config_dir: Path, *, tile_size: int = 8, crs: str = "EPSG:4326"
+) -> None:
     config_dir.mkdir(parents=True, exist_ok=True)
 
     (config_dir / "tiling.yaml").write_text(
         "\n".join(
             [
                 "tiling:",
-                "  crs: EPSG:4326",
+                f"  crs: {crs}",
                 "  global:",
                 "    min_zoom: 0",
                 "    max_zoom: 1",
@@ -91,3 +94,450 @@ def test_humidity_tile_generator_normalizes_percent_grid(
         _assert_solid_color(img, rgba=(255, 255, 255, 128))
     finally:
         img.close()
+
+
+def test_humidity_tile_generator_renders_tiles_for_surface_alias(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tiling.config import get_tiling_config
+    from tiling.humidity_tiles import HumidityTileGenerator
+
+    config_dir = tmp_path / "config"
+    _write_test_config_dir(config_dir, tile_size=2)
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    get_tiling_config.cache_clear()
+
+    lat = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    lon = np.array([-180.0, 0.0, 180.0], dtype=np.float32)
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = xr.DataArray(
+        np.array([0.0], dtype=np.float32),
+        dims=["level"],
+        attrs={"long_name": "surface", "units": "1"},
+    )
+
+    values = np.full((1, 1, lat.size, lon.size), 0.5, dtype=np.float32)
+    ds = xr.Dataset(
+        {"r": xr.DataArray(values, dims=["time", "level", "lat", "lon"])},
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+
+    generator = HumidityTileGenerator.from_dataset(ds, layer="ecmwf/humidity")
+    result = generator.generate(
+        tmp_path,
+        valid_time="2026-01-01T00:00:00Z",
+        level="surface",
+        opacity=0.5,
+        min_zoom=0,
+        max_zoom=0,
+        tile_size=2,
+        formats=("webp",),
+    )
+    assert result.level == "sfc"
+    assert result.formats == ("webp",)
+
+    tile_path = (
+        tmp_path
+        / "ecmwf"
+        / "humidity"
+        / result.time
+        / result.level
+        / "0"
+        / "0"
+        / "0.webp"
+    )
+    img = Image.open(tile_path)
+    try:
+        assert img.size == (2, 2)
+        _assert_solid_color(img.convert("RGBA"), rgba=(255, 255, 255, 64))
+    finally:
+        img.close()
+
+
+def test_humidity_tile_generator_render_tile_smoke(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tiling.config import get_tiling_config
+    from tiling.humidity_tiles import HumidityTileGenerator
+
+    config_dir = tmp_path / "config"
+    _write_test_config_dir(config_dir, tile_size=4)
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    get_tiling_config.cache_clear()
+
+    lat = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    lon = np.array([-180.0, 0.0, 180.0], dtype=np.float32)
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = np.array([850.0], dtype=np.float32)
+
+    values = np.full((1, 1, lat.size, lon.size), 50.0, dtype=np.float32)
+    ds = xr.Dataset(
+        {"r": xr.DataArray(values, dims=["time", "level", "lat", "lon"])},
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+
+    generator = HumidityTileGenerator.from_dataset(ds, layer="ecmwf/humidity")
+    img = generator.render_tile(
+        zoom=0,
+        x=0,
+        y=0,
+        valid_time="2026-01-01T00:00:00Z",
+        level="850",
+        tile_size=4,
+    )
+    assert img.size == (4, 4)
+    _assert_solid_color(img, rgba=(255, 255, 255, 128))
+
+
+def test_humidity_tile_generator_rejects_symlink_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tiling.config import get_tiling_config
+    from tiling.humidity_tiles import HumidityTileGenerator
+
+    config_dir = tmp_path / "config"
+    _write_test_config_dir(config_dir, tile_size=4)
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    get_tiling_config.cache_clear()
+
+    lat = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    lon = np.array([-180.0, 0.0, 180.0], dtype=np.float32)
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = np.array([850.0], dtype=np.float32)
+    values = np.full((1, 1, lat.size, lon.size), 50.0, dtype=np.float32)
+    ds = xr.Dataset(
+        {"r": xr.DataArray(values, dims=["time", "level", "lat", "lon"])},
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+    generator = HumidityTileGenerator.from_dataset(ds, layer="ecmwf/humidity")
+
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+
+    try:
+        (tmp_path / "ecmwf").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("Symlinks are not supported in this environment")
+
+    with pytest.raises(ValueError, match="escapes output_dir"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=("png",),
+        )
+
+
+def test_humidity_tile_generator_rejects_bad_inputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datacube.core import DataCube
+
+    from tiling.config import get_tiling_config
+    from tiling.humidity_tiles import (
+        HumidityTileGenerator,
+        HumidityTilingError,
+        _parse_time,
+        _save_tile_image,
+    )
+
+    config_dir = tmp_path / "config"
+    _write_test_config_dir(config_dir, tile_size=4)
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    get_tiling_config.cache_clear()
+
+    lat = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    lon = np.array([-180.0, 0.0, 180.0], dtype=np.float32)
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = np.array([850.0], dtype=np.float32)
+    values = np.full((1, 1, lat.size, lon.size), 50.0, dtype=np.float32)
+    ds = xr.Dataset(
+        {"r": xr.DataArray(values, dims=["time", "level", "lat", "lon"])},
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+    cube = DataCube.from_dataset(ds)
+
+    with pytest.raises(ValueError, match="unsafe characters"):
+        HumidityTileGenerator(cube, layer="../evil")
+    with pytest.raises(ValueError, match="layer must not be empty"):
+        HumidityTileGenerator(cube, layer="")
+    with pytest.raises(ValueError, match="variable must not be empty"):
+        HumidityTileGenerator(cube, variable="")
+
+    generator = HumidityTileGenerator(cube, layer="ecmwf/humidity")
+    assert generator.layer == "ecmwf/humidity"
+    assert generator.variable == "r"
+
+    with pytest.raises(ValueError, match="valid_time must not be empty"):
+        generator.generate(
+            tmp_path,
+            valid_time="",
+            level="850",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=("png",),
+        )
+
+    with pytest.raises(HumidityTilingError, match="valid_time not found"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T01:00:00Z",
+            level="850",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=("png",),
+        )
+
+    with pytest.raises(HumidityTilingError, match="level not found"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="700",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=("png",),
+        )
+
+    with pytest.raises(ValueError, match="level must not be empty"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=("png",),
+        )
+
+    with pytest.raises(ValueError, match="numeric pressure level"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="not-a-level",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=("png",),
+        )
+
+    with pytest.raises(ValueError, match="At least one tile format"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=(),
+        )
+    with pytest.raises(ValueError, match="Unsupported tile format"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=("tiff",),
+        )
+
+    with pytest.raises(ValueError, match="opacity must be between 0 and 1"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            opacity=2.0,
+            min_zoom=0,
+            max_zoom=0,
+            tile_size=4,
+            formats=("png",),
+        )
+
+    with pytest.raises(ValueError, match="tile_size must be > 0"):
+        generator.render_tile(
+            zoom=0,
+            x=0,
+            y=0,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            tile_size=0,
+        )
+
+    assert _parse_time(np.datetime64("2026-01-01T00:00:00")).tzinfo == timezone.utc
+    assert _parse_time(datetime(2026, 1, 1, 0, 0, 0)).tzinfo == timezone.utc
+    assert _parse_time("20260101T000000Z").tzinfo == timezone.utc
+    with pytest.raises(ValueError, match="ISO8601"):
+        _parse_time("not-a-time")
+
+    img = Image.new("RGBA", (1, 1), (0, 0, 0, 0))
+    with pytest.raises(ValueError, match="Unsupported tile file extension"):
+        _save_tile_image(img, tmp_path / "tile.tiff")
+
+
+def test_humidity_tile_generator_rejects_bad_config_and_zoom_range(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tiling.config import get_tiling_config
+    from tiling.humidity_tiles import HumidityTileGenerator
+
+    lat = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    lon = np.array([-180.0, 0.0, 180.0], dtype=np.float32)
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = np.array([850.0], dtype=np.float32)
+    values = np.full((1, 1, lat.size, lon.size), 50.0, dtype=np.float32)
+    ds = xr.Dataset(
+        {"r": xr.DataArray(values, dims=["time", "level", "lat", "lon"])},
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+
+    config_dir = tmp_path / "config3857"
+    _write_test_config_dir(config_dir, tile_size=4, crs="EPSG:3857")
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    get_tiling_config.cache_clear()
+
+    generator = HumidityTileGenerator.from_dataset(ds, layer="ecmwf/humidity")
+    with pytest.raises(ValueError, match="Unsupported tiling CRS"):
+        generator.render_tile(
+            zoom=0,
+            x=0,
+            y=0,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            tile_size=4,
+        )
+
+    config_dir = tmp_path / "config"
+    _write_test_config_dir(config_dir, tile_size=4)
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    get_tiling_config.cache_clear()
+
+    generator = HumidityTileGenerator.from_dataset(ds, layer="ecmwf/humidity")
+    with pytest.raises(ValueError, match="fall entirely within configured"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            opacity=1.0,
+            min_zoom=0,
+            max_zoom=2,
+            tile_size=4,
+            formats=("png",),
+        )
+
+    with pytest.raises(ValueError, match="Invalid zoom range"):
+        generator.generate(
+            tmp_path,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            opacity=1.0,
+            min_zoom=1,
+            max_zoom=0,
+            tile_size=4,
+            formats=("png",),
+        )
+
+
+def test_humidity_tile_generator_reports_dataset_shape_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datacube.core import DataCube
+
+    from tiling.config import get_tiling_config
+    from tiling.humidity_tiles import HumidityTileGenerator, HumidityTilingError
+
+    config_dir = tmp_path / "config"
+    _write_test_config_dir(config_dir, tile_size=2)
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    get_tiling_config.cache_clear()
+
+    lat = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    lon = np.array([-180.0, 0.0, 180.0], dtype=np.float32)
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = np.array([850.0], dtype=np.float32)
+
+    ds = xr.Dataset(
+        {
+            "other": xr.DataArray(
+                np.zeros((1, 1, 3, 3), dtype=np.float32),
+                dims=["time", "level", "lat", "lon"],
+            )
+        },
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+    generator = HumidityTileGenerator(DataCube(dataset=ds), layer="ecmwf/humidity")
+    with pytest.raises(HumidityTilingError, match="Variable"):
+        generator.render_tile(
+            zoom=0,
+            x=0,
+            y=0,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            tile_size=2,
+        )
+
+    ds = xr.Dataset(
+        {
+            "r": xr.DataArray(
+                np.zeros((1, 3, 3), dtype=np.float32), dims=["time", "lat", "lon"]
+            )
+        },
+        coords={
+            "time": time,
+            "level": level,
+            "lat": lat,
+            "lon": lon,
+        },
+    )
+    generator = HumidityTileGenerator(DataCube(dataset=ds), layer="ecmwf/humidity")
+    with pytest.raises(HumidityTilingError, match="required dim: level"):
+        generator.render_tile(
+            zoom=0,
+            x=0,
+            y=0,
+            valid_time="2026-01-01T00:00:00Z",
+            level="850",
+            tile_size=2,
+        )
+
+    ds = xr.Dataset(
+        {
+            "r": xr.DataArray(
+                np.zeros((1, 1, 3, 3), dtype=np.float32),
+                dims=["time", "level", "lat", "lon"],
+            )
+        },
+        coords={
+            "time": time,
+            "level": level,
+            "lat": lat,
+            "lon": lon,
+            "member": np.array([0], dtype=np.int32),
+        },
+    )
+    ds["r"] = (
+        ds["r"]
+        .expand_dims(member=ds["member"].values)
+        .transpose("time", "level", "lat", "lon", "member")
+    )
+    generator = HumidityTileGenerator(DataCube(dataset=ds), layer="ecmwf/humidity")
+    with pytest.raises(HumidityTilingError, match="Expected data dims"):
+        generator._extract_grid(time_index=0, level_index=0)
+
+    with pytest.raises(HumidityTilingError, match="time_index is out of range"):
+        generator._extract_grid(time_index=99, level_index=0)
+    with pytest.raises(HumidityTilingError, match="level_index is out of range"):
+        generator._extract_grid(time_index=0, level_index=99)

--- a/services/data-pipeline/tests/test_humidity_tiling.py
+++ b/services/data-pipeline/tests/test_humidity_tiling.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+from PIL import Image
+
+
+def _write_test_config_dir(config_dir: Path, *, tile_size: int = 8) -> None:
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    (config_dir / "tiling.yaml").write_text(
+        "\n".join(
+            [
+                "tiling:",
+                "  crs: EPSG:4326",
+                "  global:",
+                "    min_zoom: 0",
+                "    max_zoom: 1",
+                "  event:",
+                "    min_zoom: 2",
+                "    max_zoom: 2",
+                f"  tile_size: {int(tile_size)}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _assert_solid_color(img: Image.Image, *, rgba: tuple[int, int, int, int]) -> None:
+    pixels = np.asarray(img)
+    assert pixels.ndim == 3
+    assert pixels.shape[2] == 4
+    assert (pixels == np.asarray(rgba, dtype=np.uint8)).all()
+
+
+def test_humidity_tile_generator_normalizes_percent_grid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tiling.config import get_tiling_config
+    from tiling.humidity_tiles import HumidityTileGenerator
+
+    config_dir = tmp_path / "config"
+    _write_test_config_dir(config_dir, tile_size=4)
+    monkeypatch.setenv("DIGITAL_EARTH_CONFIG_DIR", str(config_dir))
+    get_tiling_config.cache_clear()
+
+    lat = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    lon = np.array([-180.0, 0.0, 180.0], dtype=np.float32)
+    time = np.array(["2026-01-01T00:00:00"], dtype="datetime64[s]")
+    level = np.array([850.0], dtype=np.float32)
+
+    # RH values are percent 0-100 but do not provide units.
+    values = np.full((1, 1, lat.size, lon.size), 50.0, dtype=np.float32)
+    ds = xr.Dataset(
+        {"r": xr.DataArray(values, dims=["time", "level", "lat", "lon"])},
+        coords={"time": time, "level": level, "lat": lat, "lon": lon},
+    )
+
+    generator = HumidityTileGenerator.from_dataset(ds, layer="ecmwf/humidity")
+    result = generator.generate(
+        tmp_path,
+        valid_time="2026-01-01T00:00:00Z",
+        level="850",
+        opacity=1.0,
+        min_zoom=0,
+        max_zoom=0,
+        tile_size=4,
+        formats=("png",),
+    )
+    assert result.time == "20260101T000000Z"
+    assert result.level == "850"
+
+    tile_path = (
+        tmp_path
+        / "ecmwf"
+        / "humidity"
+        / result.time
+        / result.level
+        / "0"
+        / "0"
+        / "0.png"
+    )
+    img = Image.open(tile_path)
+    try:
+        assert img.size == (4, 4)
+        # 50% -> 0.5 -> alpha = round(0.5 * 255) = 128
+        _assert_solid_color(img, rgba=(255, 255, 255, 128))
+    finally:
+        img.close()
+

--- a/services/data-pipeline/tests/test_humidity_tiling.py
+++ b/services/data-pipeline/tests/test_humidity_tiling.py
@@ -91,4 +91,3 @@ def test_humidity_tile_generator_normalizes_percent_grid(
         _assert_solid_color(img, rgba=(255, 255, 255, 128))
     finally:
         img.close()
-


### PR DESCRIPTION
## Summary
Add support for generating tiles at multiple pressure levels (sfc, 850, 700, 500, 300 hPa) with humidity/cloud visualization.

## Changes
- **New script**: `batch_generate_multilevel_tiles.py` - batch generation for all levels
- **New generator**: `HumidityTileGenerator` - high-altitude cloud visualization using relative humidity
- **Extended decoder**: `subset="humidity"` to decode `r@isobaricInhPa`

## Output Structure
```
Data/tiles/ecmwf/
├── temp/{time}/{level}/z/x/y.png      # Temperature
├── wind_speed/{time}/{level}/z/x/y.png # Wind speed
├── tcc/{time}/sfc/z/x/y.png           # Cloud cover (sfc only)
└── humidity/{time}/{level}/z/x/y.png  # Humidity/cloud (850/700/500/300)
```

## Usage
```bash
services/data-pipeline/.venv/bin/python services/data-pipeline/scripts/batch_generate_multilevel_tiles.py \
  --output-dir Data/tiles \
  --levels sfc,850,700,500,300 \
  --min-zoom 0 --max-zoom 6 \
  --format png
```

## Related
Closes #336