### PR TITLE
fix(web): 修复人眼模式天空黑色/灰色块

### DIFF
--- a/apps/web/src/features/viewer/CesiumViewer.test.tsx
+++ b/apps/web/src/features/viewer/CesiumViewer.test.tsx
@@ -1952,7 +1952,9 @@ describe('CesiumViewer', () => {
 
     expect(viewer.scene.skyBox.show).toBe(true);
     expect(viewer.scene.skyAtmosphere.show).toBe(true);
-    expect(viewer.scene.fog.enabled).toBe(false);
+    expect(viewer.scene.fog.enabled).toBe(true);
+    expect(viewer.scene.fog.density).toBeGreaterThan(0);
+    expect(viewer.scene.fog.density).toBeLessThan(0.001);
     expect(viewer.camera.frustum.near).toBeCloseTo(0.0615);
     expect(viewer.camera.frustum.far).toBe(49_200);
 


### PR DESCRIPTION
## Summary
修复人眼模式（Human Ground Mode）下天空区域显示黑色/灰色方块的问题。

## Root Cause
1. LocalCloudStack 瓦片 PNG 无透明处理，硬边盖住天空
2. Human 视角关闭 fog，瓦片边界暴露
3. Human frustum far 太小，大气层被裁剪
4. requestRenderMode 下贴图异步加载后未触发重绘

## Changes
- `LocalCloudStack.ts`: 新增 human 模式边缘淡化材质，贴图加载后触发 requestRender
- `CesiumViewer.tsx`: 
  - 增大 human frustum far 上限（50k → 200k）
  - 人眼模式启用轻量 fog
  - 传递 humanModeEnabled 给 LocalCloudStack

## Testing
- [x] Unit tests passing
- [x] Typecheck passing
- [x] 人眼模式天空无黑色/灰色方块
- [x] 不影响其他视角模式

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)