### PR TITLE
fix(web): layerGlobal 模式下无法取消图层显示

### DIFF
--- a/apps/web/src/features/viewer/CesiumViewer.tsx
+++ b/apps/web/src/features/viewer/CesiumViewer.tsx
@@ -2902,12 +2902,26 @@ export function CesiumViewer() {
       ? LAYER_GLOBAL_SHELL_HEIGHT_METERS_BY_LAYER_TYPE[targetLayer.type]
       : LAYER_GLOBAL_SHELL_HEIGHT_METERS_BY_LAYER_TYPE.cloud;
 
+    const key = `${sceneModeId}:${viewModeRoute.layerId}:${shellHeightMeters}:${targetLayer ? 'present' : 'missing'}`;
+    const didEnterLayerGlobal = layerGlobalEntryKeyRef.current !== key;
+
     if (targetLayer && !targetLayer.visible) {
-      useLayerManagerStore.getState().setLayerVisible(targetLayer.id, true);
+      if (didEnterLayerGlobal) {
+        useLayerManagerStore.getState().setLayerVisible(targetLayer.id, true);
+      } else {
+        const viewMode = useViewModeStore.getState();
+        const previous = viewMode.history.at(-1);
+
+        if (previous?.viewModeId === 'global') {
+          viewMode.goBack();
+        } else {
+          viewMode.replaceRoute({ viewModeId: 'global' });
+        }
+        return;
+      }
     }
 
-    const key = `${sceneModeId}:${viewModeRoute.layerId}:${shellHeightMeters}:${targetLayer ? 'present' : 'missing'}`;
-    if (layerGlobalEntryKeyRef.current === key) return;
+    if (!didEnterLayerGlobal) return;
     layerGlobalEntryKeyRef.current = key;
 
     const cartographic = viewer.camera.positionCartographic;


### PR DESCRIPTION
## Summary
修复 layerGlobal 模式下用户无法通过 checkbox 取消图层显示的问题。

## Changes
- 修改强制可见逻辑：只在进入 layerGlobal 时确保目标图层可见
- 如果用户在 layerGlobal 模式下隐藏目标图层，自动退出到 global 模式
- 优先使用 goBack 回到上一条 global 路由，否则 replaceRoute 到 global

## Testing
- [x] 单元测试覆盖隐藏后退出 layerGlobal 的两条分支
- [x] Lint/Typecheck 通过
- [x] Coverage >= 90%

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)